### PR TITLE
#242 Fix drag and drop in calendar

### DIFF
--- a/resources/seeds/Questionnaire/edit-appointment.yaml
+++ b/resources/seeds/Questionnaire/edit-appointment.yaml
@@ -113,7 +113,7 @@ item:
         linkId: start-datetime
         initialExpression:
             language: text/fhirpath
-            expression: "%CurrentAppointmentBundle.entry[0].resource.entry.resource.start"
+            expression: "%CurrentAppointment.start"
 url: https://aidbox.emr.beda.software/ui/console#/entities/Questionnaire/edit-appointment
 meta:
     profile:

--- a/src/containers/Scheduling/ScheduleCalendar/components/EditAppointmentModal/index.tsx
+++ b/src/containers/Scheduling/ScheduleCalendar/components/EditAppointmentModal/index.tsx
@@ -1,6 +1,6 @@
 import { PractitionerRole } from 'fhir/r4b';
 
-import { RenderRemoteData } from '@beda.software/fhir-react';
+import { RenderRemoteData, formatFHIRDateTime } from '@beda.software/fhir-react';
 
 import { inMemorySaveService } from 'shared/src/hooks/questionnaire-response-form-data';
 
@@ -15,10 +15,13 @@ interface Props {
     onSubmit: () => void;
     onClose: () => void;
     showModal: boolean;
+    start: Date;
 }
 
 export function EditAppointmentModal(props: Props) {
-    const { showModal, onClose, appointmentId, practitionerRole } = props;
+    const { showModal, onClose, appointmentId, practitionerRole, start } = props;
+
+    const appointmentStartDateTime = formatFHIRDateTime(start);
 
     const { response, onSubmit } = useQuestionnaireResponseForm({
         questionnaireLoader: { type: 'id', questionnaireId: 'edit-appointment' },
@@ -31,6 +34,7 @@ export function EditAppointmentModal(props: Props) {
                     id: appointmentId,
                     status: 'booked',
                     participant: [{ status: 'accepted' }],
+                    start: appointmentStartDateTime,
                 },
             },
             {

--- a/src/containers/Scheduling/ScheduleCalendar/components/EditAppointmentModal/index.tsx
+++ b/src/containers/Scheduling/ScheduleCalendar/components/EditAppointmentModal/index.tsx
@@ -15,13 +15,13 @@ interface Props {
     onSubmit: () => void;
     onClose: () => void;
     showModal: boolean;
-    start: Date;
+    start: Date | undefined | null;
 }
 
 export function EditAppointmentModal(props: Props) {
     const { showModal, onClose, appointmentId, practitionerRole, start } = props;
 
-    const appointmentStartDateTime = formatFHIRDateTime(start);
+    const appointmentStartDateTime = start ? formatFHIRDateTime(start) : formatFHIRDateTime(new Date());
 
     const { response, onSubmit } = useQuestionnaireResponseForm({
         questionnaireLoader: { type: 'id', questionnaireId: 'edit-appointment' },

--- a/src/containers/Scheduling/ScheduleCalendar/hooks/useAppointmentEvents.ts
+++ b/src/containers/Scheduling/ScheduleCalendar/hooks/useAppointmentEvents.ts
@@ -1,4 +1,4 @@
-import { DateSelectArg, EventClickArg } from '@fullcalendar/core';
+import { DateSelectArg, EventClickArg, EventDropArg } from '@fullcalendar/core';
 import { useCallback, useState } from 'react';
 
 export interface NewAppointmentData {
@@ -10,6 +10,8 @@ export function useAppointmentEvents() {
     const [newAppointmentData, setNewAppointmentData] = useState<NewAppointmentData | undefined>();
     const [appointmentDetails, setAppointmentDetails] = useState<EventClickArg['event'] | undefined>();
     const [editingAppointmentId, setEditingAppointmentId] = useState<string | undefined>();
+    const [editingAppointmentDateStart, setEditingAppointmentDateStart] = useState<Date | null>();
+    const [editingAppointmentData, setEditingAppointmentData] = useState<EventDropArg | undefined>();
 
     // function handleEventChange({ event }: EventChangeArg) {
     //     // TODO: show confirm modal and discard event change if rejected
@@ -27,17 +29,26 @@ export function useAppointmentEvents() {
     }, []);
 
     const openAppointmentDetails = useCallback((e: EventClickArg) => {
+        setEditingAppointmentDateStart(e.event.start);
         setAppointmentDetails(e.event);
     }, []);
+
     const closeAppointmentDetails = useCallback(() => {
         setAppointmentDetails(undefined);
     }, []);
 
-    const openEditAppointment = useCallback((id: string) => {
+    const openEditAppointment = useCallback((id: string, data?: EventDropArg) => {
         setEditingAppointmentId(id);
+        if (data) {
+            setEditingAppointmentDateStart(data.event.start);
+            setEditingAppointmentData(data);
+        }
     }, []);
+
     const closeEditAppointment = useCallback(() => {
         setEditingAppointmentId(undefined);
+        setEditingAppointmentData(undefined);
+        setEditingAppointmentDateStart(null);
     }, []);
 
     return {
@@ -52,5 +63,8 @@ export function useAppointmentEvents() {
         openEditAppointment,
         editingAppointmentId,
         closeEditAppointment,
+
+        editingAppointmentData,
+        editingAppointmentDateStart,
     };
 }

--- a/src/containers/Scheduling/ScheduleCalendar/hooks/useAppointmentEvents.ts
+++ b/src/containers/Scheduling/ScheduleCalendar/hooks/useAppointmentEvents.ts
@@ -10,7 +10,9 @@ export function useAppointmentEvents() {
     const [newAppointmentData, setNewAppointmentData] = useState<NewAppointmentData | undefined>();
     const [appointmentDetails, setAppointmentDetails] = useState<EventClickArg['event'] | undefined>();
     const [editingAppointmentId, setEditingAppointmentId] = useState<string | undefined>();
-    const [editingAppointmentDateStart, setEditingAppointmentDateStart] = useState<Date | null>();
+    const [editingAppointmentDateStart, setEditingAppointmentDateStart] = useState<
+        EventClickArg['event']['start'] | undefined
+    >();
     const [editingAppointmentData, setEditingAppointmentData] = useState<EventDropArg | undefined>();
 
     // function handleEventChange({ event }: EventChangeArg) {
@@ -48,7 +50,7 @@ export function useAppointmentEvents() {
     const closeEditAppointment = useCallback(() => {
         setEditingAppointmentId(undefined);
         setEditingAppointmentData(undefined);
-        setEditingAppointmentDateStart(null);
+        setEditingAppointmentDateStart(undefined);
     }, []);
 
     return {

--- a/src/containers/Scheduling/ScheduleCalendar/index.tsx
+++ b/src/containers/Scheduling/ScheduleCalendar/index.tsx
@@ -37,8 +37,10 @@ export function ScheduleCalendar({ practitionerRole }: Props) {
         appointmentDetails,
         closeAppointmentDetails,
         openEditAppointment,
-        editingAppointmentId,
         closeEditAppointment,
+        editingAppointmentData,
+        editingAppointmentId,
+        editingAppointmentDateStart,
     } = useAppointmentEvents();
 
     return (
@@ -69,6 +71,9 @@ export function ScheduleCalendar({ practitionerRole }: Props) {
                                     eventContent={AppointmentBubble}
                                     eventClick={openAppointmentDetails}
                                     select={openNewAppointmentModal}
+                                    eventDrop={(info) => {
+                                        openEditAppointment(info.event.id, info);
+                                    }}
                                     buttonText={{
                                         today: t`Today`,
                                         week: t`Week`,
@@ -111,7 +116,11 @@ export function ScheduleCalendar({ practitionerRole }: Props) {
                                                 message: t`Appointment successfully rescheduled`,
                                             });
                                         }}
-                                        onClose={closeEditAppointment}
+                                        onClose={() => {
+                                            editingAppointmentData?.revert();
+                                            closeEditAppointment();
+                                        }}
+                                        start={editingAppointmentDateStart || new Date()}
                                     />
                                 )}
                                 {newAppointmentData && (

--- a/src/containers/Scheduling/ScheduleCalendar/index.tsx
+++ b/src/containers/Scheduling/ScheduleCalendar/index.tsx
@@ -120,7 +120,7 @@ export function ScheduleCalendar({ practitionerRole }: Props) {
                                             editingAppointmentData?.revert();
                                             closeEditAppointment();
                                         }}
-                                        start={editingAppointmentDateStart || new Date()}
+                                        start={editingAppointmentDateStart}
                                     />
                                 )}
                                 {newAppointmentData && (


### PR DESCRIPTION
You can drag and drop events in the schedule calendar.
However, it is just a UI feature. Once a page is reloaded all changes resets.
Once this task is completed the drop event should popup Appointment edit modal with the updated date/time.
If user save the event is updated. On cancel event should be restored on the initla date/time