### PR TITLE
Add common config to fix empty import error

### DIFF
--- a/shared/src/config.common.tsx
+++ b/shared/src/config.common.tsx
@@ -1,0 +1,3 @@
+const commonConfig = {};
+
+export default commonConfig;


### PR DESCRIPTION
created a dummy config.common to eliminate `shared/src/config/ts` empty import error:

```
import commonConfig from './config.common';

export default {
    ...commonConfig,
```