### PR TITLE
Fix path for group

### DIFF
--- a/src/components/BaseQuestionnaireResponseForm/widgets/Group/index.tsx
+++ b/src/components/BaseQuestionnaireResponseForm/widgets/Group/index.tsx
@@ -50,7 +50,7 @@ function Flex(props: GroupItemProps & { type?: GroupContextProps['type'] }) {
                 >
                     <QuestionItems
                         questionItems={item}
-                        parentPath={[...parentPath, linkId, 'items']}
+                        parentPath={[...parentPath, linkId, 'item']}
                         context={context[0]!}
                     />
                 </div>


### PR DESCRIPTION
Is it a bug in group definition or we use item**s** instead of item in the internal form representation format?