### PR TITLE
Add check if prevData is undefined for nested group parsing in history diff

### DIFF
--- a/src/containers/PatientDetails/DocumentHistory/utils.ts
+++ b/src/containers/PatientDetails/DocumentHistory/utils.ts
@@ -43,7 +43,7 @@ export function getFormDataDiff(initialCurrentData: FormItems, initialPrevData: 
 
         _.toPairs(currentData).forEach(([linkId, data]) => {
             if (isGroup(data)) {
-                const groupDiff = generateDiff(data.items, prevData[linkId]?.items);
+                const groupDiff = generateDiff(data.items, prevData ? prevData[linkId]?.items : undefined);
                 diffAfter = { ...diffAfter, ...groupDiff.diffAfter };
                 diffBefore = { ...diffBefore, ...groupDiff.diffBefore };
 


### PR DESCRIPTION
Required for https://github.com/RSDUE/rsdue_emr/issues/171

Error appears when parsing group items inside group items