### PR TITLE
Add custom path for dashboard card link

### DIFF
--- a/src/containers/PatientDetails/PatientOverviewDynamic/components/LinkToEdit/index.tsx
+++ b/src/containers/PatientDetails/PatientOverviewDynamic/components/LinkToEdit/index.tsx
@@ -2,8 +2,14 @@ import { Resource, Provenance } from 'fhir/r4b';
 import { Link, useLocation } from 'react-router-dom';
 import { fromFHIRReference } from 'sdc-qrf';
 
-export function LinkToEdit(props: { name?: string; resource: Resource; provenanceList: Provenance[] }) {
-    const { name, resource, provenanceList } = props;
+interface LinkToEditProps {
+    name?: string;
+    resource: Resource;
+    provenanceList: Provenance[];
+    to?: string;
+}
+export function LinkToEdit(props: LinkToEditProps) {
+    const { name, resource, provenanceList, to } = props;
     const location = useLocation();
     const provenance = provenanceList.find(
         (p) =>
@@ -14,7 +20,7 @@ export function LinkToEdit(props: { name?: string; resource: Resource; provenanc
     const qrId = fromFHIRReference(entity)?.id;
 
     if (qrId) {
-        return <Link to={`${location.pathname}/documents/${qrId}`}>{name}</Link>;
+        return <Link to={to ? `${to}/${qrId}` : `${location.pathname}/documents/${qrId}`}>{name}</Link>;
     }
 
     return <>{name}</>;

--- a/src/containers/PatientDetails/PatientOverviewDynamic/components/StandardCard/prepare.tsx
+++ b/src/containers/PatientDetails/PatientOverviewDynamic/components/StandardCard/prepare.tsx
@@ -69,6 +69,7 @@ export function prepareConditions(
     conditions: Condition[],
     provenanceList: Provenance[],
     total?: number,
+    to?: string,
 ): OverviewCard<Condition> {
     return {
         title: t`Conditions`,
@@ -86,6 +87,7 @@ export function prepareConditions(
                         name={resource.code?.text || resource.code?.coding?.[0]?.display}
                         resource={resource}
                         provenanceList={provenanceList}
+                        to={to}
                     />
                 ),
             },
@@ -107,6 +109,7 @@ export function prepareConsents(
     consents: Consent[],
     provenanceList: Provenance[],
     total?: number,
+    to?: string,
 ): OverviewCard<Consent> {
     return {
         title: t`Consents`,
@@ -129,6 +132,7 @@ export function prepareConsents(
                             name={provisionName || purposeName || category}
                             resource={resource}
                             provenanceList={provenanceList}
+                            to={to}
                         />
                     );
                 },
@@ -186,6 +190,7 @@ export function prepareImmunizations(
     observations: Immunization[],
     provenanceList: Provenance[],
     total?: number,
+    to?: string,
 ): OverviewCard<Immunization> {
     return {
         title: t`Immunization`,
@@ -203,6 +208,7 @@ export function prepareImmunizations(
                         name={resource.vaccineCode.coding?.[0]?.display}
                         resource={resource}
                         provenanceList={provenanceList}
+                        to={to}
                     />
                 ),
             },
@@ -220,6 +226,7 @@ export function prepareMedications(
     observations: MedicationStatement[],
     provenanceList: Provenance[],
     total?: number,
+    to?: string,
 ): OverviewCard<MedicationStatement> {
     return {
         title: t`Active Medications`,
@@ -237,6 +244,7 @@ export function prepareMedications(
                         name={resource.medicationCodeableConcept?.coding?.[0]?.display}
                         resource={resource}
                         provenanceList={provenanceList}
+                        to={to}
                     />
                 ),
             },

--- a/src/containers/PatientDetails/PatientOverviewDynamic/components/StandardCard/prepare.tsx
+++ b/src/containers/PatientDetails/PatientOverviewDynamic/components/StandardCard/prepare.tsx
@@ -29,6 +29,7 @@ export function prepareAllergies(
     allergies: AllergyIntolerance[],
     provenanceList: Provenance[],
     total?: number,
+    to?: string,
 ): OverviewCard<AllergyIntolerance> {
     return {
         title: t`Allergies`,
@@ -46,6 +47,7 @@ export function prepareAllergies(
                         name={resource.code?.coding?.[0]?.display}
                         resource={resource}
                         provenanceList={provenanceList}
+                        to={to}
                     />
                 ),
             },

--- a/src/containers/PatientDetails/PatientOverviewDynamic/components/StandardCard/types.ts
+++ b/src/containers/PatientDetails/PatientOverviewDynamic/components/StandardCard/types.ts
@@ -16,5 +16,5 @@ export interface OverviewCard<T extends Resource | Resource[]> {
 }
 
 export type PrepareFunction<T extends Resource> =
-    | ((resources: T[], provenances: Provenance[], total: number) => OverviewCard<T>)
+    | ((resources: T[], provenances: Provenance[], total: number, to?: string) => OverviewCard<T>)
     | ((resources: T[]) => OverviewCard<T[]>);

--- a/src/containers/PatientDetails/PatientOverviewDynamic/containers/StandardCardContainerFabric/hooks.ts
+++ b/src/containers/PatientDetails/PatientOverviewDynamic/containers/StandardCardContainerFabric/hooks.ts
@@ -14,6 +14,7 @@ export function useStandardCard<T extends Resource>(
     patient: Patient,
     query: Query,
     prepareFunction: PrepareFunction<T>,
+    to?: string,
 ) {
     const [response] = useService(async () => {
         return mapSuccess(
@@ -29,6 +30,7 @@ export function useStandardCard<T extends Resource>(
                     resource as T[],
                     provenance,
                     resource.length,
+                    to,
                 );
                 return { card };
             },


### PR DESCRIPTION
Use case:
when using several dashboards with several contexts to create and render
documents at it becomes handy to have optional ability to pass 'to'
component from DashboardInstance

Ref https://github.com/breeoot/ehr/issues/278