### PR TITLE
Add default page size to usePagerExtended

### DIFF
--- a/src/hooks/pager.ts
+++ b/src/hooks/pager.ts
@@ -11,8 +11,9 @@ export function usePagerExtended<T extends Resource, F = unknown>(
     resourceType: string,
     searchParams?: SearchParams,
     debouncedFilterValues?: F,
+    defaultPageSize?: number,
 ) {
-    const [pageSize, setPageSize] = useState(10);
+    const [pageSize, setPageSize] = useState(defaultPageSize ?? 10);
 
     const [resourceResponse, pagerManager] = usePager<T>({
         resourceType,


### PR DESCRIPTION
Allows setting default page size to pull and render tables of different length
