### PR TITLE
Add MDEditorControl to itemControlComponents

### DIFF
--- a/src/components/BaseQuestionnaireResponseForm/controls.tsx
+++ b/src/components/BaseQuestionnaireResponseForm/controls.tsx
@@ -26,6 +26,7 @@ import {
     Gtable,
     QuestionQuantity,
     Grid,
+    MDEditorControl,
 } from './widgets';
 import { Display } from './widgets/display';
 import { GroupWizard, GroupWizardWithTooltips } from './widgets/GroupWizard';
@@ -64,6 +65,7 @@ export const itemControlComponents: ItemControlQuestionItemComponentMapping = {
     'reference-radio-button': ReferenceRadioButton,
     'check-box': InlineChoice,
     'input-inside-text': QuestionInputInsideText,
+    'markdown-editor': MDEditorControl,
 };
 
 export const groupControlComponents: ItemControlGroupItemComponentMapping = {

--- a/src/components/BaseQuestionnaireResponseForm/widgets/index.ts
+++ b/src/components/BaseQuestionnaireResponseForm/widgets/index.ts
@@ -12,4 +12,5 @@ export * from './insideText';
 export * from './boolean';
 export * from './TimeRangePickerControl';
 export * from './DateTimeSlotPicker';
-export * from './UploadFileControl'
+export * from './UploadFileControl';
+export * from './MDEditorControl';


### PR DESCRIPTION
Required to force MDEditorControl be fully built and added to `dist` when using fhir-emr as package