### PR TITLE
Add search param to search for active q's to create documents

### DIFF
--- a/src/containers/DocumentsList/ChooseDocumentToCreateModal/index.tsx
+++ b/src/containers/DocumentsList/ChooseDocumentToCreateModal/index.tsx
@@ -34,6 +34,7 @@ export const ChooseDocumentToCreateModal = (props: Props) => {
                     'subject-type': subjectType ? [subjectType] : [],
                     _sort: 'title',
                     ...(context ? { context } : {}),
+                    status: 'active',
                 }),
                 (bundle) => extractBundleResources(bundle).Questionnaire,
             ),

--- a/src/containers/DocumentsList/ChooseDocumentToCreateModal/index.tsx
+++ b/src/containers/DocumentsList/ChooseDocumentToCreateModal/index.tsx
@@ -33,8 +33,8 @@ export const ChooseDocumentToCreateModal = (props: Props) => {
                 await getFHIRResources<Questionnaire>('Questionnaire', {
                     'subject-type': subjectType ? [subjectType] : [],
                     _sort: 'title',
-                    ...(context ? { context } : {}),
                     status: 'active',
+                    ...(context ? { context } : {}),
                 }),
                 (bundle) => extractBundleResources(bundle).Questionnaire,
             ),


### PR DESCRIPTION
NOTE: used when constructing list of questionnaires on Patient's documents page and in Encounter

Shows only questionnaires with  status='active'