### PR TITLE
Make 'share link' button optional when creating document

### DIFF
--- a/src/containers/DocumentsList/ChooseDocumentToCreateModal/index.tsx
+++ b/src/containers/DocumentsList/ChooseDocumentToCreateModal/index.tsx
@@ -19,10 +19,11 @@ interface Props extends ModalProps {
     context?: string;
     onCancel: () => void;
     openNewTab?: boolean;
+    displayShareButton?: boolean;
 }
 
 export const ChooseDocumentToCreateModal = (props: Props) => {
-    const { subjectType, patient, encounter, onCancel, context, openNewTab } = props;
+    const { subjectType, patient, encounter, onCancel, context, openNewTab, displayShareButton = true } = props;
     const [questionnaireId, setQuestionnaireId] = useState();
     const location = useLocation();
     const navigate = useNavigate();
@@ -53,26 +54,30 @@ export const ChooseDocumentToCreateModal = (props: Props) => {
                     <Button key="back" onClick={onCloseModal}>
                         <Trans>Cancel</Trans>
                     </Button>,
-                    <Button
-                        key="share-link"
-                        disabled={!questionnaireId}
-                        onClick={() => {
-                            const questionnaireParams = _.compact([
-                                `patient=${patient.id}`,
-                                `questionnaire=${questionnaireId}`,
-                                encounter?.id ? `encounter=${encounter.id}` : null,
-                            ]);
-                            navigator.clipboard.writeText(
-                                `${window.location.origin}/questionnaire?${questionnaireParams.join('&')}`,
-                            );
-                            notification.success({
-                                message: t`The link was copied to clipboard`,
-                            });
-                            onCloseModal();
-                        }}
-                    >
-                        <Trans>Share link</Trans>
-                    </Button>,
+                    ...(displayShareButton
+                        ? [
+                              <Button
+                                  key="share-link"
+                                  disabled={!questionnaireId}
+                                  onClick={() => {
+                                      const questionnaireParams = _.compact([
+                                          `patient=${patient.id}`,
+                                          `questionnaire=${questionnaireId}`,
+                                          encounter?.id ? `encounter=${encounter.id}` : null,
+                                      ]);
+                                      navigator.clipboard.writeText(
+                                          `${window.location.origin}/questionnaire?${questionnaireParams.join('&')}`,
+                                      );
+                                      notification.success({
+                                          message: t`The link was copied to clipboard`,
+                                      });
+                                      onCloseModal();
+                                  }}
+                              >
+                                  <Trans>Share link</Trans>
+                              </Button>,
+                          ]
+                        : []),
                     <Button
                         key="create"
                         disabled={!questionnaireId}

--- a/src/containers/EncounterDetails/hooks.ts
+++ b/src/containers/EncounterDetails/hooks.ts
@@ -20,6 +20,7 @@ export interface EncounterDetailsProps {
     hideControls?: boolean;
     documentTypes?: Array<DocumentType>;
     openNewTab?: boolean;
+    displayShareButton?: boolean;
 }
 
 export function useEncounterDetails(props: EncounterDetailsProps) {

--- a/src/containers/EncounterDetails/index.tsx
+++ b/src/containers/EncounterDetails/index.tsx
@@ -135,6 +135,7 @@ export const EncounterDetails = (props: EncounterDetailsProps) => {
                                 encounter={encounter}
                                 context={modalOpened.context}
                                 openNewTab={props.openNewTab}
+                                displayShareButton={props.displayShareButton}
                             />
 
                             {showScriber ||

--- a/src/containers/PatientDetails/PatientDocuments/index.tsx
+++ b/src/containers/PatientDetails/PatientDocuments/index.tsx
@@ -14,6 +14,7 @@ interface Props {
     title?: string;
     context?: string;
     openNewTab?: boolean;
+    displayShareButton?: boolean;
 }
 
 export const PatientDocuments = (props: Props) => {
@@ -39,6 +40,7 @@ export const PatientDocuments = (props: Props) => {
                         subjectType="Patient"
                         context={props.context}
                         openNewTab={props.openNewTab}
+                        displayShareButton={props.displayShareButton}
                     />
                 </div>
             )}


### PR DESCRIPTION
In some use cases it is desired to hide "Share link" button in ChooseDocumentToCreateModal