### PR TITLE
PATCH: update `_sort` with `_id` when using Pager

### DIFF
--- a/src/components/ResourceTable/index.tsx
+++ b/src/components/ResourceTable/index.tsx
@@ -33,7 +33,7 @@ interface ResourceTableProps<R extends Resource> extends ResourceTableHookProps<
 export function useResourceTable<R extends Resource>(props: ResourceTableHookProps<R>) {
     const { resourceType, params = {} } = props;
     const queryParameters = {
-        _sort: '-_lastUpdated',
+        _sort: ['-_lastUpdated', '_id'],
         ...params,
     };
 

--- a/src/containers/EncounterList/hooks.ts
+++ b/src/containers/EncounterList/hooks.ts
@@ -44,7 +44,7 @@ export function useEncounterList(
         'participant-display': practitionerFilterValue,
         'subject:Patient.id': patientFilterValue,
         date: dateFilterValue,
-        _sort: '-_date',
+        _sort: ['-_date', '_id'],
     };
 
     const { resourceResponse, pagerManager, handleTableChange, pagination } = usePagerExtended<

--- a/src/containers/HealthcareServiceList/hooks.ts
+++ b/src/containers/HealthcareServiceList/hooks.ts
@@ -14,7 +14,7 @@ export function useHealthcareServiceList(filterValues: ColumnFilterValue[]) {
     const healthcareServiceFilterValue = getSearchBarFilterValue(filterValues, 'service');
 
     const queryParameters = {
-        _sort: '-_lastUpdated',
+        _sort: ['-_lastUpdated', '_id'],
         ilike: healthcareServiceFilterValue,
     };
 

--- a/src/containers/InvoiceList/hooks.ts
+++ b/src/containers/InvoiceList/hooks.ts
@@ -7,7 +7,7 @@ import { usePagerExtended } from 'src/hooks/pager';
 
 export function useInvoicesList(practitionerId?: string, patientId?: string, status?: string) {
     const queryParameters = {
-        _sort: '-_lastUpdated',
+        _sort: ['-_lastUpdated', '_id'],
         status: status,
         subject: patientId,
         participant: practitionerId,

--- a/src/containers/PatientDetails/PatientOrders/index.tsx
+++ b/src/containers/PatientDetails/PatientOrders/index.tsx
@@ -214,7 +214,7 @@ export function PatientOrders({ patient }: Props) {
                     patient: patient.id,
                     category: 'laboratory',
                     status: 'final',
-                    _sort: ['-_lastUpdated'],
+                    _sort: ['-_lastUpdated', '_id'],
                     _revinclude: ['Provenance:target'],
                     _ilike: search,
                 }}

--- a/src/containers/PatientDetails/PatientResources/utils.tsx
+++ b/src/containers/PatientDetails/PatientResources/utils.tsx
@@ -39,7 +39,7 @@ export function getOptions(patient: WithId<Patient>): Option[] {
                     resourceType="MedicationStatement"
                     params={{
                         patient: patient.id,
-                        _sort: ['-_lastUpdated'],
+                        _sort: ['-_lastUpdated', '_id'],
                         _revinclude: ['Provenance:target'],
                     }}
                     getTableColumns={option.getTableColumns}
@@ -74,7 +74,7 @@ export function getOptions(patient: WithId<Patient>): Option[] {
                     resourceType="Condition"
                     params={{
                         patient: patient.id,
-                        _sort: ['-_recorded-date'],
+                        _sort: ['-_recorded-date', '_id'],
                         _revinclude: ['Provenance:target'],
                     }}
                     getTableColumns={option.getTableColumns}
@@ -113,7 +113,7 @@ export function getOptions(patient: WithId<Patient>): Option[] {
                     resourceType="AllergyIntolerance"
                     params={{
                         patient: patient.id,
-                        _sort: ['-_date'],
+                        _sort: ['-_date', '_id'],
                         _revinclude: ['Provenance:target'],
                     }}
                     getTableColumns={option.getTableColumns}
@@ -152,7 +152,7 @@ export function getOptions(patient: WithId<Patient>): Option[] {
                     resourceType="Immunization"
                     params={{
                         patient: patient.id,
-                        _sort: ['-_date'],
+                        _sort: ['-_date', '_id'],
                         _revinclude: ['Provenance:target'],
                     }}
                     getTableColumns={option.getTableColumns}
@@ -188,7 +188,7 @@ export function getOptions(patient: WithId<Patient>): Option[] {
                     params={{
                         patient: patient.id,
                         status: 'active',
-                        _sort: ['-_lastUpdated'],
+                        _sort: ['-_lastUpdated', '_id'],
                         _revinclude: ['Provenance:target'],
                     }}
                     getTableColumns={option.getTableColumns}
@@ -235,7 +235,7 @@ export function getOptions(patient: WithId<Patient>): Option[] {
                     params={{
                         patient: patient.id,
                         status: 'final',
-                        _sort: ['-_lastUpdated'],
+                        _sort: ['-_lastUpdated', '_id'],
                         _revinclude: ['Provenance:target'],
                     }}
                     getTableColumns={option.getTableColumns}
@@ -310,7 +310,7 @@ export function getOptions(patient: WithId<Patient>): Option[] {
                     resourceType="ServiceRequest"
                     params={{
                         patient: patient.id,
-                        _sort: ['-_lastUpdated'],
+                        _sort: ['-_lastUpdated', '_id'],
                     }}
                     getTableColumns={option.getTableColumns}
                 />

--- a/src/containers/PatientList/hooks.ts
+++ b/src/containers/PatientList/hooks.ts
@@ -20,7 +20,7 @@ export function usePatientList(filterValues: ColumnFilterValue[], searchParams: 
         : { name: patientFilterValue };
 
     const defaultQueryParameters = {
-        _sort: '-_lastUpdated',
+        _sort: ['-_lastUpdated', '_id'],
         ...(patientFilterValue ? searchParamKeyForPatientName : {}),
     };
 

--- a/src/containers/PractitionerList/hooks.ts
+++ b/src/containers/PractitionerList/hooks.ts
@@ -25,7 +25,7 @@ export function usePractitionersList(filterValues: ColumnFilterValue[] | undefin
     const practitionerFilterValue = getSearchBarFilterValue(filterValues, 'practitioner');
 
     const queryParameters = {
-        _sort: '-_lastUpdated',
+        _sort: ['-_lastUpdated', '_id'],
         name: practitionerFilterValue,
     };
 

--- a/src/containers/Prescriptions/hooks.ts
+++ b/src/containers/Prescriptions/hooks.ts
@@ -16,7 +16,7 @@ export function useMedicationRequest(requesterId?: string, subjectId?: string, s
             'MedicationRequest:requester',
             'MedicationRequest:medication:Medication',
         ],
-        _sort: '-_createdAt',
+        _sort: ['-_createdAt', '_id'],
     };
 
     const { resourceResponse, pagerManager, handleTableChange, pagination } = usePagerExtended<

--- a/src/containers/QuestionnaireList/hooks.ts
+++ b/src/containers/QuestionnaireList/hooks.ts
@@ -14,7 +14,7 @@ export function useQuestionnaireList(filterValues: ColumnFilterValue[]) {
     const questionnaireFilterValue = getSearchBarFilterValue(filterValues, 'questionnaire');
 
     const queryParameters = {
-        _sort: '-_lastUpdated',
+        _sort: ['-_lastUpdated', '_id'],
         name: questionnaireFilterValue,
     };
 


### PR DESCRIPTION
Consistency of sorting is especially inportant when used with Pager. Adding second distinct parameter solves that.