### PR TITLE
PATCH: set z-index of MDEditor toolbar to 0

### DIFF
--- a/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/MarkDownEditor/index.tsx
+++ b/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/MarkDownEditor/index.tsx
@@ -16,6 +16,7 @@ import { useEffect, useRef } from 'react';
 import { useTheme } from 'styled-components';
 
 import '@mdxeditor/editor/style.css';
+import { S } from './styles';
 
 interface MarkDownEditorProps {
     markdownString: string;
@@ -36,13 +37,7 @@ export function MarkDownEditor({ markdownString = '', readOnly = false, onChange
 
     // TODO Add a button to add link and make a custom modal to enter the link
     // https://mdxeditor.dev/editor/api/functions/linkDialogPlugin
-    const plugins = [
-        headingsPlugin(),
-        listsPlugin(),
-        quotePlugin(),
-        linkPlugin(),
-        markdownShortcutPlugin(),
-    ];
+    const plugins = [headingsPlugin(), listsPlugin(), quotePlugin(), linkPlugin(), markdownShortcutPlugin()];
 
     if (!readOnly) {
         plugins.push(
@@ -64,15 +59,17 @@ export function MarkDownEditor({ markdownString = '', readOnly = false, onChange
     }
 
     return (
-        <MDXEditor
-            className={theme.mode === 'dark' ? 'dark-theme' : ''}
-            ref={mdxEditorRef}
-            readOnly={readOnly}
-            markdown={markdownString}
-            onChange={onChange}
-            contentEditableClassName="MarkDownEditorContent"
-            plugins={plugins}
-        />
+        <S.MDXEditorWrapper>
+            <MDXEditor
+                className={theme.mode === 'dark' ? 'dark-theme' : ''}
+                ref={mdxEditorRef}
+                readOnly={readOnly}
+                markdown={markdownString}
+                onChange={onChange}
+                contentEditableClassName="MarkDownEditorContent"
+                plugins={plugins}
+            />
+        </S.MDXEditorWrapper>
     );
 }
 

--- a/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/MarkDownEditor/styles.ts
+++ b/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/MarkDownEditor/styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const S = {
+    MDXEditorWrapper: styled.div`
+        .mdxeditor-toolbar {
+            z-index: 0;
+        }
+    `,
+};


### PR DESCRIPTION
By default @mdxeditor/editor/MDXEditor sets z-index for toolbar to 2 That interferes with select component