### PR TITLE
Enhancements to MarkdownEditor component and itemControl

### DIFF
--- a/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/MarkDownEditor/context.tsx
+++ b/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/MarkDownEditor/context.tsx
@@ -1,10 +1,11 @@
 import { RealmPlugin } from '@mdxeditor/editor';
 import React, { createContext } from 'react';
+import { ItemContext } from 'sdc-qrf';
 
 export type MarkDownEditorContextProps = {
-    commonPlugins?: RealmPlugin[];
-    toolbarPlugins?: React.ReactNode[];
     MarkdownEditorWrapper?: React.ComponentType<any>;
+    initPlugins?: (context?: ItemContext) => RealmPlugin[];
+    initToolbarPlugins?: (context?: ItemContext) => React.ReactNode[];
 };
 
 export const MarkDownEditorContext = createContext<MarkDownEditorContextProps>({});

--- a/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/MarkDownEditor/context.tsx
+++ b/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/MarkDownEditor/context.tsx
@@ -1,0 +1,10 @@
+import { RealmPlugin } from '@mdxeditor/editor';
+import React, { createContext } from 'react';
+
+export type MarkDownEditorContextProps = {
+    commonPlugins?: RealmPlugin[];
+    toolbarPlugins?: React.ReactNode[];
+    MarkdownEditorWrapper?: React.ComponentType<any>;
+};
+
+export const MarkDownEditorContext = createContext<MarkDownEditorContextProps>({});

--- a/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/MarkDownEditor/index.tsx
+++ b/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/MarkDownEditor/index.tsx
@@ -19,15 +19,17 @@ import '@mdxeditor/editor/style.css';
 import { Divider } from 'antd';
 import { MarkDownEditorContext } from './context';
 import { S } from './styles';
+import { ItemContext } from 'sdc-qrf';
 
 interface MarkDownEditorProps {
     markdownString: string;
     onChange?: (markdown: string) => void;
     readOnly?: boolean;
+    context?: ItemContext;
 }
 
 export function MarkDownEditor(props: MarkDownEditorProps) {
-    const { markdownString = '', readOnly = false, onChange } = props;
+    const { markdownString = '', readOnly = false, onChange, context } = props;
     const mdxEditorRef = useRef<MDXEditorMethods>(null);
 
     useEffect(() => {
@@ -43,12 +45,12 @@ export function MarkDownEditor(props: MarkDownEditorProps) {
     // TODO Add a button to add link and make a custom modal to enter the link
     // https://mdxeditor.dev/editor/api/functions/linkDialogPlugin
     const plugins = useMemo(() => {
-        const commonPlugins = pluginsContext.commonPlugins
-            ? pluginsContext.commonPlugins
+        const commonPlugins = pluginsContext.initPlugins
+            ? pluginsContext.initPlugins(context)
             : [headingsPlugin(), listsPlugin(), quotePlugin(), linkPlugin(), markdownShortcutPlugin()];
 
-        const toolbarPlugins = pluginsContext.toolbarPlugins
-            ? pluginsContext.toolbarPlugins
+        const toolbarPlugins = pluginsContext.initToolbarPlugins
+            ? pluginsContext.initToolbarPlugins(context)
             : [
                   <UndoRedo />,
                   <Divider type="vertical" />,
@@ -76,7 +78,7 @@ export function MarkDownEditor(props: MarkDownEditorProps) {
               ];
 
         return plugins;
-    }, [pluginsContext.commonPlugins, pluginsContext.toolbarPlugins, readOnly]);
+    }, [pluginsContext.initPlugins, pluginsContext.initToolbarPlugins, readOnly, context]);
 
     const MDXEditorWrapper = pluginsContext.MarkdownEditorWrapper || S.MDXEditorWrapper;
 

--- a/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/MarkDownEditor/styles.ts
+++ b/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/MarkDownEditor/styles.ts
@@ -2,8 +2,29 @@ import styled from 'styled-components';
 
 export const S = {
     MDXEditorWrapper: styled.div`
+        transition: all 0.2s;
+
+        .mdxeditor {
+            border: 1px solid ${({ theme }) => theme.neutralPalette.gray_5};
+            border-radius: 8px;
+        }
+
+        .mdxeditor:hover {
+            border-color: ${({ theme }) => theme.primary}cc;
+        }
+
+        .mdxeditor:focus-within {
+            border-color: ${({ theme }) => theme.primary};
+            box-shadow: 0 0 0 2px ${({ theme }) => theme.primary}0d;
+        }
+
         .mdxeditor-toolbar {
             z-index: 0;
+            position: unset;
+        }
+
+        .mdxeditor-popup-container {
+            z-index: 1000;
         }
     `,
 };

--- a/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/index.tsx
+++ b/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/index.tsx
@@ -3,11 +3,16 @@ import { QuestionItemProps } from 'sdc-qrf';
 import { useFieldController } from 'src/components/BaseQuestionnaireResponseForm/hooks';
 
 import { MarkDownEditor } from './MarkDownEditor';
+import { Form } from 'antd';
 
 export function MDEditorControl({ parentPath, questionItem }: QuestionItemProps) {
     const { linkId } = questionItem;
     const fieldName = [...parentPath, linkId, 0, 'value', 'string'];
-    const { value, onChange } = useFieldController(fieldName, questionItem);
+    const { value, onChange, formItem } = useFieldController(fieldName, questionItem);
 
-    return <MarkDownEditor markdownString={value} onChange={onChange} readOnly={questionItem.readOnly} />;
+    return (
+        <Form.Item {...formItem}>
+            <MarkDownEditor markdownString={value} onChange={onChange} readOnly={questionItem.readOnly} />
+        </Form.Item>
+    );
 }

--- a/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/index.tsx
+++ b/src/components/BaseQuestionnaireResponseForm/widgets/MDEditorControl/index.tsx
@@ -5,14 +5,19 @@ import { useFieldController } from 'src/components/BaseQuestionnaireResponseForm
 import { MarkDownEditor } from './MarkDownEditor';
 import { Form } from 'antd';
 
-export function MDEditorControl({ parentPath, questionItem }: QuestionItemProps) {
+export function MDEditorControl({ parentPath, questionItem, context }: QuestionItemProps) {
     const { linkId } = questionItem;
     const fieldName = [...parentPath, linkId, 0, 'value', 'string'];
     const { value, onChange, formItem } = useFieldController(fieldName, questionItem);
 
     return (
         <Form.Item {...formItem}>
-            <MarkDownEditor markdownString={value} onChange={onChange} readOnly={questionItem.readOnly} />
+            <MarkDownEditor
+                markdownString={value}
+                onChange={onChange}
+                readOnly={questionItem.readOnly}
+                context={context}
+            />
         </Form.Item>
     );
 }


### PR DESCRIPTION
1. Display field text when used as itemControl Ref https://github.com/beda-software/fhir-emr/issues/419
2. Move plugins and toolbar components to context