### PR TITLE
Add date time format customization

### DIFF
--- a/src/components/BaseQuestionnaireResponseForm/widgets/date.tsx
+++ b/src/components/BaseQuestionnaireResponseForm/widgets/date.tsx
@@ -1,20 +1,15 @@
 import { Form } from 'antd';
 import moment, { type Moment } from 'moment';
-import { useCallback, useContext, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { QuestionItemProps } from 'sdc-qrf';
 
-import {
-    FHIRTimeFormat,
-    formatFHIRDate,
-    formatFHIRDateTime,
-    formatFHIRTime,
-} from '@beda.software/fhir-react';
+import { FHIRTimeFormat, formatFHIRDate, formatFHIRDateTime, formatFHIRTime } from '@beda.software/fhir-react';
 
 import { DatePicker } from 'src/components/DatePicker';
 import { TimePicker } from 'src/components/TimePicker';
 
 import { useFieldController } from '../hooks';
-import { DateTimeFormatContext } from 'src/contexts/date-time-format';
+import { humanDate, humanDateTime, humanTime } from 'src/utils/date';
 
 export function QuestionDateTime({ parentPath, questionItem }: QuestionItemProps) {
     const { linkId, type, regex } = questionItem;
@@ -45,7 +40,6 @@ interface DateTimePickerWrapperProps {
 }
 
 function DateTimePickerWrapper(props: DateTimePickerWrapperProps) {
-    const { humanDate, humanTime, humanDateTime } = useContext(DateTimeFormatContext);
     const { value, onChange, type, disabled, placeholder, format } = props;
 
     const newValue = useMemo(() => {

--- a/src/contexts/date-time-format.ts
+++ b/src/contexts/date-time-format.ts
@@ -1,7 +1,0 @@
-import { createContext } from 'react';
-
-import { humanDate, humanDateTime, humanDateYearMonth, humanTime } from 'src/utils/date';
-
-export const defaultDateTimeFormats = { humanDate, humanDateYearMonth, humanTime, humanDateTime };
-
-export const DateTimeFormatContext = createContext(defaultDateTimeFormats);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,7 +17,6 @@ import { ValueSetExpandProvider } from './contexts';
 import { expandEMRValueSet } from './services';
 import * as serviceWorker from './serviceWorker';
 import { ThemeProvider } from './theme/ThemeProvider';
-import { DateTimeFormatContext, defaultDateTimeFormats } from './contexts/date-time-format';
 
 const AppWithContext = () => {
     useEffect(() => {
@@ -26,15 +25,13 @@ const AppWithContext = () => {
 
     return (
         <I18nProvider i18n={i18n}>
-            <DateTimeFormatContext.Provider value={defaultDateTimeFormats}>
-                <PatientDashboardProvider dashboard={dashboard}>
-                    <ValueSetExpandProvider.Provider value={expandEMRValueSet}>
-                        <ThemeProvider>
-                            <App />
-                        </ThemeProvider>
-                    </ValueSetExpandProvider.Provider>
-                </PatientDashboardProvider>
-            </DateTimeFormatContext.Provider>
+            <PatientDashboardProvider dashboard={dashboard}>
+                <ValueSetExpandProvider.Provider value={expandEMRValueSet}>
+                    <ThemeProvider>
+                        <App />
+                    </ThemeProvider>
+                </ValueSetExpandProvider.Provider>
+            </PatientDashboardProvider>
         </I18nProvider>
     );
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -3,10 +3,32 @@ import _ from 'lodash';
 
 import { parseFHIRDate, parseFHIRDateTime } from '@beda.software/fhir-react';
 
-export const humanDate = 'DD MMM YYYY';
-export const humanDateYearMonth = 'MMM YYYY';
-export const humanTime = 'HH:mm';
-export const humanDateTime = 'DD MMM YYYY HH:mm';
+export let humanDate = 'DD MMM YYYY';
+export let humanDateYearMonth = 'MMM YYYY';
+export let humanTime = 'HH:mm';
+export let humanDateTime = 'DD MMM YYYY HH:mm';
+
+export type DateTimeFormat = {
+    humanDate: string;
+    humanDateYearMonth: string;
+    humanTime: string;
+    humanDateTime: string;
+};
+
+export const setDateTimeFormats = (formats: Partial<DateTimeFormat>) => {
+    if (formats.humanDate) {
+        humanDate = formats.humanDate;
+    }
+    if (formats.humanDateYearMonth) {
+        humanDateYearMonth = formats.humanDateYearMonth;
+    }
+    if (formats.humanTime) {
+        humanTime = formats.humanTime;
+    }
+    if (formats.humanDateTime) {
+        humanDateTime = formats.humanDateTime;
+    }
+};
 
 export const formatHumanDateTime = (date?: string) => {
     if (!date) {


### PR DESCRIPTION
## Motivation:
A clean way to customise date and time formats

## Usage:
```typescript
// Import setDateTimeFormats function
import { setDateTimeFormats } from '@beda.software/emr/dist/utils/date';

export const AppWithContext = () => {
    useEffect(() => {
        // Call it here. 
        // Pass only formats you want to override.
        // EMR formats are used by default.
        setDateTimeFormats({ humanDate: 'MM/DD/YYYY', humanDateTime: 'MM/DD/YYYY HH:mm' });

        dynamicActivate(getCurrentLocale());
    }, []);
    return <App />;
};
```

## Migration guide:
**! BREAKING CHANGE in case of using DateTimeFormatContext only !**
1.Remove <DateTimeFormatContext.Provider value={defaultDateTimeFormats}>...</DateTimeFormatContext.Provider>
2. Use setDateTimeFormats instead