### PR TITLE
Feat/add customizations

### DIFF
--- a/src/components/BaseLayout/Sidebar/SidebarBottom/index.tsx
+++ b/src/components/BaseLayout/Sidebar/SidebarBottom/index.tsx
@@ -17,10 +17,11 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
     collapsed: boolean;
     toggleCollapsed?: () => void;
     onItemClick?: () => void;
+    enableLocaleSwitcher?: boolean;
 }
 
 export function SidebarBottom(props: Props) {
-    const { collapsed, toggleCollapsed, onItemClick, ...other } = props;
+    const { collapsed, toggleCollapsed, onItemClick, enableLocaleSwitcher = true, ...other } = props;
     const appToken = getToken();
     const isAnonymousUser = !appToken;
 
@@ -32,7 +33,7 @@ export function SidebarBottom(props: Props) {
             {...other}
         >
             <S.Divider $hidden={collapsed} />
-            <LocaleSwitcher onItemClick={onItemClick} />
+            {enableLocaleSwitcher && <LocaleSwitcher onItemClick={onItemClick} />}
             {!isAnonymousUser ? (
                 <>
                     <S.Divider $hidden={collapsed} />

--- a/src/components/QuestionnaireResponseForm/index.tsx
+++ b/src/components/QuestionnaireResponseForm/index.tsx
@@ -36,6 +36,7 @@ export interface QRFProps extends QuestionnaireResponseFormProps {
     FormFooterComponent?: React.ElementType<FormFooterComponentProps>;
     saveButtonTitle?: React.ReactNode;
     cancelButtonTitle?: React.ReactNode;
+    autoSave?: boolean;
 }
 
 export const saveQuestionnaireResponseDraft = async (


### PR DESCRIPTION
# 1. Disable language switcher

## Motivation:
For projects that use only one language the language switch element in a side bar is redundant.
<img width="250" alt="image" src="https://github.com/user-attachments/assets/d633f31c-704a-4875-82c8-68295ee5cfc0" />

Desired appearance:
<img width="248" alt="image" src="https://github.com/user-attachments/assets/25a5723d-a350-4ab1-98cb-119a5f3fe1b0" />


## Solution:
Add `enableLocaleSwitcher` boolean param to `SidebarBottom`

## Usage example:

```tsx
<SidebarBottom
    collapsed={collapsed}
    toggleCollapsed={() => setCollapsed((v) => !v)}
    enableLocaleSwitcher={false}
/>
```

# 2. Pass autoSave props
```tsx
<QuestionnaireResponseForm
    // ...                                
    autoSave={true}
/>
 ```