### PR TITLE
Add ProvenanceBundle resource to launchContext when opening PatientDocument

### DIFF
--- a/src/containers/PatientDetails/PatientDocument/usePatientDocument.ts
+++ b/src/containers/PatientDetails/PatientDocument/usePatientDocument.ts
@@ -75,7 +75,7 @@ function prepareFormInitialParams(
     props: Props & {
         provenance?: WithId<Provenance>;
         author?: WithId<Practitioner | Patient | Organization>;
-        provenanceBundle?: Bundle<Provenance>;
+        provenanceBundle?: Bundle<WithId<Provenance>>;
     },
 ): QuestionnaireResponseFormProps {
     const {
@@ -161,10 +161,10 @@ export function usePatientDocument(props: Props): {
             );
             const lastProvenance = descSortedProvenances[0];
 
-            const provenanceBundle: Bundle<Provenance> = {
+            const provenanceBundle: Bundle<WithId<Provenance>> = {
                 resourceType: 'Bundle',
                 type: 'collection',
-                entry: provenanceResponse.data,
+                entry: provenanceResponse.data.map((provenance) => ({ resource: provenance })),
             };
 
             const formInitialParams = prepareFormInitialParams({

--- a/src/containers/PatientDetails/PatientDocument/usePatientDocument.ts
+++ b/src/containers/PatientDetails/PatientDocument/usePatientDocument.ts
@@ -1,4 +1,5 @@
 import {
+    Bundle,
     Encounter,
     Organization,
     ParametersParameter,
@@ -74,6 +75,7 @@ function prepareFormInitialParams(
     props: Props & {
         provenance?: WithId<Provenance>;
         author?: WithId<Practitioner | Patient | Organization>;
+        provenanceBundle?: Bundle<Provenance>;
     },
 ): QuestionnaireResponseFormProps {
     const {
@@ -84,6 +86,7 @@ function prepareFormInitialParams(
         provenance,
         author,
         launchContextParameters = [],
+        provenanceBundle,
     } = props;
 
     const params = {
@@ -107,6 +110,14 @@ function prepareFormInitialParams(
                       {
                           name: 'Provenance',
                           resource: provenance,
+                      },
+                  ]
+                : []),
+            ...(provenanceBundle
+                ? [
+                      {
+                          name: 'ProvenanceBundle',
+                          resource: provenanceBundle,
                       },
                   ]
                 : []),
@@ -150,9 +161,16 @@ export function usePatientDocument(props: Props): {
             );
             const lastProvenance = descSortedProvenances[0];
 
+            const provenanceBundle: Bundle<Provenance> = {
+                resourceType: 'Bundle',
+                type: 'collection',
+                entry: provenanceResponse.data,
+            };
+
             const formInitialParams = prepareFormInitialParams({
                 ...props,
                 provenance: lastProvenance,
+                provenanceBundle: provenanceBundle,
             });
 
             const onSubmit = async (formData: QuestionnaireResponseFormData) =>


### PR DESCRIPTION
`ProvenanceBundle` becomes available in Questionnaire and Mapping contexts.

This way we can fully utilize ability to assign a number of mappers to questionnaire or use several subQuestionnaires within one Questionnaire each with its own mapper,  and each of them can create and read their own Provenance resources.