### PR TITLE
Add prop to Quantity widget dropdown

### DIFF
--- a/src/components/BaseQuestionnaireResponseForm/widgets/number.tsx
+++ b/src/components/BaseQuestionnaireResponseForm/widgets/number.tsx
@@ -94,6 +94,7 @@ export function QuestionQuantity(props: QuestionItemProps) {
                             onChange={onUnitChange}
                             style={{ minWidth: 70 }}
                             disabled={disabled}
+                            popupMatchSelectWidth={false}
                         >
                             {unitOption.map((option) => (
                                 <Select.Option key={option.code} value={option.display}>


### PR DESCRIPTION
Setting `popMatchSelectWidth` to  `false` allows dropdown to match options' width

Before:
![Screenshot From 2025-01-21 20-23-58](https://github.com/user-attachments/assets/4306b8b1-dfaf-42f6-bb10-3154131d3c6c)

After:
![Screenshot From 2025-01-21 20-22-15](https://github.com/user-attachments/assets/d339a0e5-81fc-47cf-92df-295b82f787c1)
