### PR TITLE
Add the ability to configure sorting in ResourceListPage

### DIFF
--- a/src/components/SearchBar/types.ts
+++ b/src/components/SearchBar/types.ts
@@ -165,3 +165,10 @@ export interface SearchBarData {
     onChangeColumnFilter: (value: ColumnFilterValue['value'], key: string) => void;
     onResetFilters: () => void;
 }
+
+export interface SorterColumn {
+    id: string;
+    searchParam: string;
+    label: string;
+    // NOTE: add placement? prtoperty similar to SearchBarColumn
+}

--- a/src/components/Table/utils.tsx
+++ b/src/components/Table/utils.tsx
@@ -1,9 +1,9 @@
 import { ColumnsType, ColumnType } from 'antd/lib/table';
-import { FilterDropdownProps } from 'antd/lib/table/interface';
+import { FilterDropdownProps, SorterResult } from 'antd/lib/table/interface';
 import { Bundle, Resource } from 'fhir/r4b';
 import _ from 'lodash';
 
-import { ColumnFilterValue } from 'src/components/SearchBar/types';
+import { ColumnFilterValue, SorterColumn } from 'src/components/SearchBar/types';
 
 import { TableFilter } from './TableFilter';
 
@@ -12,13 +12,15 @@ export type RecordType<R extends Resource> = { resource: R; bundle: Bundle };
 interface Props<R extends Resource> {
     tableColumns: ColumnsType<RecordType<R>>;
     filters: ColumnFilterValue[];
+    sorters: SorterColumn[];
+    currentSorter: SorterResult;
     onChange: (value: ColumnFilterValue['value'], key: string) => void;
 }
 
 export function populateTableColumnsWithFiltersAndSorts<R extends Resource>(
     props: Props<R>,
 ): ColumnsType<RecordType<R>> {
-    const { tableColumns, filters, onChange } = props;
+    const { tableColumns, filters, sorters, currentSorter, onChange } = props;
     const result = tableColumns.map((column) => {
         const filter = filters.find((f) => f.column.id === column.key);
 
@@ -28,6 +30,8 @@ export function populateTableColumnsWithFiltersAndSorts<R extends Resource>(
             filterDropdown: filter
                 ? (props: FilterDropdownProps) => <TableFilter {...props} filter={filter} onChange={onChange} />
                 : undefined,
+            sorter: !!sorters.find((sorter) => sorter.id === column.key),
+            sortOrder: currentSorter.columnKey === column.key ? currentSorter.order : undefined,
         };
 
         return updatedColumn;

--- a/src/containers/PatientResourceListExample/index.tsx
+++ b/src/containers/PatientResourceListExample/index.tsx
@@ -108,6 +108,13 @@ export function PatientResourceListExample() {
                     placement: ['table'],
                 },
             ]}
+            getSorters={() => [
+                {
+                    id: 'name',
+                    searchParam: 'name',
+                    label: 'Name',
+                },
+            ]}
             getRecordActions={(record) => [
                 navigationAction('Open', `/patients/${record.resource.id}`),
                 questionnaireAction('Edit', 'patient-edit'),

--- a/src/uberComponents/ResourceListPage/index.tsx
+++ b/src/uberComponents/ResourceListPage/index.tsx
@@ -1,6 +1,7 @@
 import { Trans } from '@lingui/macro';
 import { Empty } from 'antd';
 import { ColumnsType, TablePaginationConfig } from 'antd/lib/table';
+import { FilterValue, SorterResult } from 'antd/lib/table/interface';
 import { Bundle, ParametersParameter, Resource } from 'fhir/r4b';
 import React, { useCallback, useMemo } from 'react';
 
@@ -31,7 +32,7 @@ import {
 } from './actions';
 export { navigationAction, customAction, questionnaireAction } from './actions';
 import { BatchActions } from './BatchActions';
-import { useResourceListPage } from './hooks';
+import { useResourceListPage, useTableSorter } from './hooks';
 import { S } from './styles';
 import { ResourceListProps, ReportColumn, TableManager } from './types';
 
@@ -54,16 +55,18 @@ export function ResourceListPage<R extends Resource>({
     resourceType,
     extractPrimaryResources,
     extractChildrenResources,
-    searchParams,
+    searchParams: defaultSearchParams,
     getRecordActions,
     getHeaderActions,
     getBatchActions,
     getFilters,
+    getSorters,
     getTableColumns,
     defaultLaunchContext,
     getReportColumns,
 }: ResourceListPageProps<R>) {
     const allFilters = getFilters?.() ?? [];
+    const allSorters = useMemo(() => getSorters?.() ?? [], [getSorters]);
 
     const { columnsFilterValues, onChangeColumnFilter, onResetFilters } = useSearchBar({
         columns: allFilters ?? [],
@@ -73,26 +76,32 @@ export function ResourceListPage<R extends Resource>({
         [JSON.stringify(columnsFilterValues)],
     );
 
+    const { sortSearchParam, setCurrentSorter, currentSorter } = useTableSorter(allSorters, defaultSearchParams);
+
     const { recordResponse, reload, pagination, selectedRowKeys, setSelectedRowKeys, selectedResourcesBundle } =
-        useResourceListPage(
-            resourceType,
-            extractPrimaryResources,
-            extractChildrenResources,
-            columnsFilterValues,
-            searchParams ?? {},
-        );
+        useResourceListPage(resourceType, extractPrimaryResources, extractChildrenResources, columnsFilterValues, {
+            ...defaultSearchParams,
+            _sort: sortSearchParam,
+        });
 
     const handleTableChange = useCallback(
-        (event: TablePaginationConfig) => {
-            if (typeof event.current !== 'number') {
+        (
+            paginationConfig: TablePaginationConfig,
+            _filters: Record<string, FilterValue | null>,
+            sorter: SorterResult<RecordType<R>> | SorterResult<RecordType<R>>[],
+        ) => {
+            if (!Array.isArray(sorter)) {
+                setCurrentSorter(sorter as any as SorterResult);
+            }
+            if (typeof paginationConfig.current !== 'number') {
                 return;
             }
-            if (event.pageSize && event.pageSize !== pagination.pageSize) {
+            if (paginationConfig.pageSize && paginationConfig.pageSize !== pagination.pageSize) {
                 pagination.reload();
-                pagination.updatePageSize(event.pageSize);
+                pagination.updatePageSize(paginationConfig.pageSize);
             } else {
-                pagination.loadPage(event.current, {
-                    _page: event.current,
+                pagination.loadPage(paginationConfig.current, {
+                    _page: paginationConfig.current,
                 });
             }
             setSelectedRowKeys([]);
@@ -105,6 +114,8 @@ export function ResourceListPage<R extends Resource>({
     const tableColumns = populateTableColumnsWithFiltersAndSorts({
         tableColumns: initialTableColumns,
         filters: tableFilterValues,
+        sorters: allSorters,
+        currentSorter,
         onChange: onChangeColumnFilter,
     });
     const headerActions = getHeaderActions?.() ?? [];

--- a/src/uberComponents/ResourceListPage/types.ts
+++ b/src/uberComponents/ResourceListPage/types.ts
@@ -2,7 +2,7 @@ import { Bundle, ParametersParameter, Resource } from 'fhir/r4b';
 
 import { SearchParams } from '@beda.software/fhir-react';
 
-import { SearchBarColumn } from '../../components/SearchBar/types';
+import { SearchBarColumn, SorterColumn } from '../../components/SearchBar/types';
 
 export type RecordType<R extends Resource> = { resource: R; bundle: Bundle; children?: RecordType<R>[] };
 
@@ -42,6 +42,7 @@ export interface ResourceListProps<R extends Resource, Extra = unknown, Link = s
 
     /* Filter that are displayed in the search bar and inside table columns */
     getFilters?: () => SearchBarColumn[];
+    getSorters?: () => SorterColumn[];
 
     /**
      * Record actions list that is displayed in the table per record


### PR DESCRIPTION
Added `getSorters` property to `ResourceListProps` for sorting configuration. See the [example](https://github.com/beda-software/fhir-emr/compare/resource-list-page-sorting?expand=1#diff-973effb9b529eae340f371aa4e641b2c1243d1a9d686bc261a42f11f07be3b41R111)