### PR TITLE
Proposal: add split-string searchBar column

### DIFF
--- a/src/components/SearchBar/SearchBarColumn/SplitStringColumn/hooks.ts
+++ b/src/components/SearchBar/SearchBarColumn/SplitStringColumn/hooks.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+
+import { SearchBarColumnSplitStringTypeProps } from '../types';
+
+export function useSplitStringColumn(props: SearchBarColumnSplitStringTypeProps) {
+    const { onChange, columnFilterValue } = props;
+
+    const onColumnChange = useCallback(
+        (event: React.ChangeEvent<HTMLInputElement>) => {
+            onChange(event.target.value, columnFilterValue.column.id);
+        },
+        [onChange, columnFilterValue],
+    );
+
+    return { onColumnChange };
+}

--- a/src/components/SearchBar/SearchBarColumn/SplitStringColumn/index.tsx
+++ b/src/components/SearchBar/SearchBarColumn/SplitStringColumn/index.tsx
@@ -1,0 +1,19 @@
+import { Input } from 'antd';
+
+import { useSplitStringColumn } from './hooks';
+import { SearchBarColumnSplitStringTypeProps } from '../types';
+
+export function SplitStringColumn(props: SearchBarColumnSplitStringTypeProps) {
+    const { columnFilterValue } = props;
+
+    const { onColumnChange } = useSplitStringColumn(props);
+
+    return (
+        <Input.Search
+            placeholder={columnFilterValue.column.placeholder}
+            value={columnFilterValue.value}
+            onChange={onColumnChange}
+            allowClear
+        />
+    );
+}

--- a/src/components/SearchBar/SearchBarColumn/index.tsx
+++ b/src/components/SearchBar/SearchBarColumn/index.tsx
@@ -3,6 +3,7 @@ import { DateColumn } from './DateColumn';
 import { DateSingleColumn } from './DateSingleColumn';
 import { ReferenceColumn } from './ReferenceColumn';
 import { SolidChoiceColumn } from './SolidChoiceColumn';
+import { SplitStringColumn } from './SplitStringColumn';
 import { StringColumn } from './StringColumn';
 import { SearchBarColumnProps } from './types';
 import {
@@ -12,6 +13,7 @@ import {
     isChoiceColumnFilterValue,
     isSolidChoiceColumnFilterValue,
     isSingleDateColumnFilterValue,
+    isSplitStringColumnFilterValue,
 } from '../types';
 
 export function SearchBarColumn(props: SearchBarColumnProps) {
@@ -64,6 +66,14 @@ export function SearchBarColumn(props: SearchBarColumnProps) {
         };
 
         return <SolidChoiceColumn {...choiceProps} />;
+    }
+
+    if (isSplitStringColumnFilterValue(columnFilterValue)) {
+        const splitStringProps = {
+            ...props,
+            columnFilterValue,
+        };
+        return <SplitStringColumn {...splitStringProps} />;
     }
 
     return null;

--- a/src/components/SearchBar/SearchBarColumn/types.ts
+++ b/src/components/SearchBar/SearchBarColumn/types.ts
@@ -6,6 +6,7 @@ import {
     ReferenceTypeColumnFilterValue,
     StringTypeColumnFilterValue,
     SingleDateTypeColumnFilterValue,
+    SplitStringTypeColumnFilterValue,
 } from '../types';
 
 export type SearchBarColumnProps = {
@@ -46,4 +47,9 @@ export interface SearchBarColumnChoiceTypeProps {
 export interface SearchBarColumnSolidChoiceTypeProps {
     columnFilterValue: SolidChoiceTypeColumnFilterValue;
     onChange: (value: SolidChoiceTypeColumnFilterValue['value'], key: string) => void;
+}
+
+export interface SearchBarColumnSplitStringTypeProps {
+    columnFilterValue: SplitStringTypeColumnFilterValue;
+    onChange: (value: SplitStringTypeColumnFilterValue['value'], key: string) => void;
 }

--- a/src/components/SearchBar/hooks.ts
+++ b/src/components/SearchBar/hooks.ts
@@ -16,6 +16,8 @@ import {
     isSolidChoiceColumnFilterValue,
     isSingleDateColumn,
     isSingleDateColumnFilterValue,
+    isSplitStringColumn,
+    isSplitStringColumnFilterValue,
 } from './types';
 import {
     validateStringColumnFilterValue,
@@ -24,6 +26,7 @@ import {
     validateChoiceColumnFilterValue,
     validateSolidChoiceColumnFilterValue,
     validateSingleDateColumnFilterValue,
+    validateSplitStringColumnFilterValue,
 } from './validate';
 
 export function useSearchBar(props: SearchBarProps): SearchBarData {
@@ -62,6 +65,10 @@ export function useSearchBar(props: SearchBarProps): SearchBarData {
 
             if (isSolidChoiceColumn(column)) {
                 return { column, value: column.defaultValue ? [column.defaultValue] : null };
+            }
+
+            if (isSplitStringColumn(column)) {
+                return { column, value: column.defaultValue ?? undefined };
             }
 
             throw new Error('Unsupported column type');
@@ -117,6 +124,13 @@ export function useSearchBar(props: SearchBarProps): SearchBarData {
 
                     if (isSolidChoiceColumnFilterValue(newFilterValue)) {
                         if (validateSolidChoiceColumnFilterValue(value)) {
+                            newFilterValue.value = value;
+                            return newFilterValue;
+                        }
+                    }
+
+                    if (isSplitStringColumnFilterValue(newFilterValue)) {
+                        if (validateSplitStringColumnFilterValue(value)) {
                             newFilterValue.value = value;
                             return newFilterValue;
                         }

--- a/src/components/SearchBar/types.ts
+++ b/src/components/SearchBar/types.ts
@@ -11,6 +11,7 @@ export enum SearchBarColumnType {
     REFERENCE = 'reference',
     CHOICE = 'choice',
     SOLIDCHOICE = 'solidChoice',
+    SPLITSTRING = 'splitString',
 }
 
 export interface SearchBarProps {
@@ -72,13 +73,21 @@ export type SearchBarSolidChoiceColumn = SearchBarColumnBase & {
     defaultValue?: Coding;
 };
 
+export type SearchBarSplitStringColumn = SearchBarColumnBase & {
+    type: SearchBarColumnType.SPLITSTRING;
+    placeholder: string;
+    defaultValue?: string;
+};
+
 export type SearchBarColumn =
     | SearchBarStringColumn
     | SearchBarDateColumn
     | SearchBarSingleDateColumn
     | SearchBarReferenceColumn
     | SearchBarChoiceColumn
-    | SearchBarSolidChoiceColumn;
+    | SearchBarSolidChoiceColumn
+    | SearchBarSplitStringColumn;
+
 export function isStringColumn(column: SearchBarColumn): column is SearchBarStringColumn {
     return column.type === SearchBarColumnType.STRING;
 }
@@ -96,6 +105,9 @@ export function isChoiceColumn(column: SearchBarColumn): column is SearchBarChoi
 }
 export function isSolidChoiceColumn(column: SearchBarColumn): column is SearchBarSolidChoiceColumn {
     return column.type === SearchBarColumnType.SOLIDCHOICE;
+}
+export function isSplitStringColumn(column: SearchBarColumn): column is SearchBarSplitStringColumn {
+    return column.type === SearchBarColumnType.SPLITSTRING;
 }
 
 export type DateColumnFilterValue = [moment.Moment, moment.Moment];
@@ -128,13 +140,20 @@ export interface SolidChoiceTypeColumnFilterValue {
     value?: Coding[] | null;
 }
 
+export interface SplitStringTypeColumnFilterValue {
+    column: SearchBarSplitStringColumn;
+    value?: string;
+}
+
 export type ColumnFilterValue =
     | StringTypeColumnFilterValue
     | DateTypeColumnFilterValue
     | SingleDateTypeColumnFilterValue
     | ReferenceTypeColumnFilterValue
     | ChoiceTypeColumnFilterValue
-    | SolidChoiceTypeColumnFilterValue;
+    | SolidChoiceTypeColumnFilterValue
+    | SplitStringTypeColumnFilterValue;
+
 export function isStringColumnFilterValue(filterValue: ColumnFilterValue): filterValue is StringTypeColumnFilterValue {
     return isStringColumn(filterValue.column);
 }
@@ -158,6 +177,11 @@ export function isSolidChoiceColumnFilterValue(
     filterValue: ColumnFilterValue,
 ): filterValue is SolidChoiceTypeColumnFilterValue {
     return isSolidChoiceColumn(filterValue.column);
+}
+export function isSplitStringColumnFilterValue(
+    filterValue: ColumnFilterValue,
+): filterValue is SplitStringTypeColumnFilterValue {
+    return isSplitStringColumn(filterValue.column);
 }
 
 export interface SearchBarData {

--- a/src/components/SearchBar/types.ts
+++ b/src/components/SearchBar/types.ts
@@ -77,6 +77,8 @@ export type SearchBarSplitStringColumn = SearchBarColumnBase & {
     type: SearchBarColumnType.SPLITSTRING;
     placeholder: string;
     defaultValue?: string;
+    searchBehavior: 'AND' | 'OR';
+    separator?: string;
 };
 
 export type SearchBarColumn =

--- a/src/components/SearchBar/utils.ts
+++ b/src/components/SearchBar/utils.ts
@@ -53,7 +53,11 @@ export function getSearchBarColumnFilterValue(filterValue: ColumnFilterValue) {
     }
 
     if (isSplitStringColumnFilterValue(filterValue)) {
-        return filterValue.value?.split(' ');
+        if (filterValue.column.searchBehavior === 'AND') {
+            return filterValue.value?.split(filterValue.column.separator ?? ' ');
+        } else {
+            return filterValue.value?.split(filterValue.column.separator ?? ' ').join(',');
+        }
     }
 
     throw new Error('Unsupported column type');

--- a/src/components/SearchBar/utils.ts
+++ b/src/components/SearchBar/utils.ts
@@ -7,6 +7,7 @@ import {
     isReferenceColumnFilterValue,
     isSingleDateColumnFilterValue,
     isSolidChoiceColumnFilterValue,
+    isSplitStringColumnFilterValue,
     isStringColumnFilterValue,
     SearchBarColumn,
 } from './types';
@@ -49,6 +50,10 @@ export function getSearchBarColumnFilterValue(filterValue: ColumnFilterValue) {
 
     if (isSolidChoiceColumnFilterValue(filterValue)) {
         return filterValue.value?.map((option) => option.code!);
+    }
+
+    if (isSplitStringColumnFilterValue(filterValue)) {
+        return filterValue.value?.split(' ').join(',');
     }
 
     throw new Error('Unsupported column type');

--- a/src/components/SearchBar/utils.ts
+++ b/src/components/SearchBar/utils.ts
@@ -53,7 +53,7 @@ export function getSearchBarColumnFilterValue(filterValue: ColumnFilterValue) {
     }
 
     if (isSplitStringColumnFilterValue(filterValue)) {
-        return filterValue.value?.split(' ').join(',');
+        return filterValue.value?.split(' ');
     }
 
     throw new Error('Unsupported column type');

--- a/src/components/SearchBar/validate.ts
+++ b/src/components/SearchBar/validate.ts
@@ -8,6 +8,7 @@ import {
     ReferenceTypeColumnFilterValue,
     SingleDateTypeColumnFilterValue,
     SolidChoiceTypeColumnFilterValue,
+    SplitStringTypeColumnFilterValue,
     StringTypeColumnFilterValue,
 } from './types';
 
@@ -88,4 +89,14 @@ export function validateSolidChoiceColumnFilterValue(
     }
 
     throw new Error('Invalid solid choice column filter value');
+}
+
+export function validateSplitStringColumnFilterValue(
+    value?: ColumnFilterValue['value'],
+): value is SplitStringTypeColumnFilterValue['value'] {
+    if (_.isUndefined(value) || _.isString(value)) {
+        return true;
+    }
+
+    throw new Error('Invalid split string column filter value');
 }

--- a/src/containers/PatientList/index.tsx
+++ b/src/containers/PatientList/index.tsx
@@ -21,9 +21,11 @@ const makeFilters = (searchParam: string): SearchBarColumn[] => [
     {
         id: 'name',
         searchParam,
-        type: SearchBarColumnType.STRING,
+        type: SearchBarColumnType.SPLITSTRING,
         placeholder: t`Find patient`,
         placement: ['search-bar', 'table'],
+        searchBehavior: 'AND',
+        separator: ' ',
     },
 ];
 
@@ -90,7 +92,7 @@ function buildColumns<R extends Resource>(
 }
 
 function PatientListConsent(props: { searchParams: SearchParams }) {
-    const getFilters = (): SearchBarColumn[] => makeFilters('patient:Patient.name');
+    const getFilters = (): SearchBarColumn[] => makeFilters('patient:Patient.name:contains');
     const getTableColumns = (_manager: TableManager): ColumnsType<RecordType<Consent>> =>
         buildColumns<Consent>((record) => getPatientFromConsent(record.resource, record.bundle));
 
@@ -120,7 +122,7 @@ function PatientListConsent(props: { searchParams: SearchParams }) {
 }
 
 function PatientListDefault(props: { searchParams: SearchParams }) {
-    const getFilters = (): SearchBarColumn[] => makeFilters('name');
+    const getFilters = (): SearchBarColumn[] => makeFilters('name:contains');
     const getTableColumns = (_manager: TableManager): ColumnsType<RecordType<Patient>> =>
         buildColumns<Patient>((record) => record.resource);
 


### PR DESCRIPTION
Allows turning filters to fuzzy-like behavior.
E.g. `name:contains=John Doe` → `name:contains=John,Doe`