### PR TITLE
Update config for hybrid terminology engine

### DIFF
--- a/env/aidbox
+++ b/env/aidbox
@@ -27,7 +27,10 @@ BOX_INIT_BUNDLE=file:///resources/init-bundles/initBundle.json
 
 AIDBOX_FHIR_SCHEMA_VALIDATION=true
 AIDBOX_FHIR_PACKAGES=hl7.fhir.r4b.core#4.3.0
-AIDBOX_TERMINOLOGY_SERVICE_BASE_URL=https://tx.health-samurai.io/fhir
+
+BOX_FHIR_TERMINOLOGY_SERVICE_BASE_URL=https://tx.health-samurai.io/fhir
+BOX_FHIR_TERMINOLOGY_ENGINE=hybrid
+BOX_FHIR_TERMINOLOGY_ENGINE_HYBRID_EXTERNAL_TX_SERVER=https://tx.health-samurai.io/fhir
 
 BOX_FHIR_SEARCH_ENGINE=jsonpath
 BOX_SEARCH_ENGINE=jsonpath

--- a/src/components/SearchBar/SearchBarColumn/ChoiceColumn/__tests__/ValueSetColumn.test.ts
+++ b/src/components/SearchBar/SearchBarColumn/ChoiceColumn/__tests__/ValueSetColumn.test.ts
@@ -9,9 +9,9 @@ import {
     SearchBarColumnType,
 } from 'src/components/SearchBar/types';
 import { ValueSetOption } from 'src/services';
-import { createValueSet, loginAdminUser } from 'src/setupTests';
+import { createCodeSystem, createValueSet, loginAdminUser } from 'src/setupTests';
 
-import { valuesetEncounterStatusData } from './valuesetEncounterStatus';
+import { codeSystemEncounterStatusData, valuesetEncounterStatusData } from './valuesetEncounterStatus';
 import { useChoiceColumn } from '../hooks';
 
 const VALUE_SET_COLUMN_CASES: SearchBarChoiceColumn[] = [
@@ -19,20 +19,21 @@ const VALUE_SET_COLUMN_CASES: SearchBarChoiceColumn[] = [
         id: 'status_valueset1',
         type: SearchBarColumnType.CHOICE,
         placeholder: 'Search by vastatus',
-        valueSet: 'http://hl7.org/fhir/ValueSet/encounter-status',
+        valueSet: 'http://hl7.org/fhir/ValueSet/encounter-status-test',
     },
     {
         id: 'status_valueset2',
         type: SearchBarColumnType.CHOICE,
         placeholder: 'Search by vastatus',
         repeats: true,
-        valueSet: 'http://hl7.org/fhir/ValueSet/encounter-status',
+        valueSet: 'http://hl7.org/fhir/ValueSet/encounter-status-test',
     },
 ];
 
 describe('ValueSetColumn component testing', () => {
     beforeAll(async () => {
         await loginAdminUser();
+        await createCodeSystem(codeSystemEncounterStatusData);
         await createValueSet(valuesetEncounterStatusData);
     });
 
@@ -63,6 +64,8 @@ describe('ValueSetColumn component testing', () => {
                 };
             });
 
+            await new Promise((r) => setTimeout(r, 2000));
+
             expect(result.current.columnsFilterValues).toHaveLength(1);
             expect(isChoiceColumnFilterValue(result.current.columnsFilterValues[0]!)).toBeTruthy();
 
@@ -78,9 +81,7 @@ describe('ValueSetColumn component testing', () => {
 
             const options = mockCallback.mock.calls[0][0];
 
-            const valuesetEncounterStatusCodes = valuesetEncounterStatusData.compose!.include[0]!.concept!.map(
-                (concept) => concept.code,
-            );
+            const valuesetEncounterStatusCodes = codeSystemEncounterStatusData.concept!.map((concept) => concept.code);
 
             await waitFor(() => {
                 expect(options.length).toEqual(valuesetEncounterStatusCodes.length);

--- a/src/components/SearchBar/SearchBarColumn/ChoiceColumn/__tests__/valuesetEncounterStatus.ts
+++ b/src/components/SearchBar/SearchBarColumn/ChoiceColumn/__tests__/valuesetEncounterStatus.ts
@@ -1,72 +1,62 @@
-import { ValueSet } from '@beda.software/aidbox-types';
+import { CodeSystem, ValueSet } from '@beda.software/aidbox-types';
+
+export const codeSystemEncounterStatusData: CodeSystem = {
+    id: 'encounter-status',
+    resourceType: 'CodeSystem',
+    status: 'active',
+    url: 'http://hl7.org/fhir/encounter-status-test',
+    name: 'encounter-status',
+    content: 'complete',
+    version: '0.0.1',
+    concept: [
+        {
+            code: 'planned',
+            display: 'Planned',
+        },
+        {
+            code: 'in-progress',
+            display: 'In Progress',
+        },
+        {
+            code: 'on-hold',
+            display: 'On Hold',
+        },
+        {
+            code: 'discharged',
+            display: 'Discharged',
+        },
+        {
+            code: 'finished',
+            display: 'Finished',
+        },
+        {
+            code: 'cancelled',
+            display: 'Cancelled',
+        },
+        {
+            code: 'entered-in-error',
+            display: 'Entered in Error',
+        },
+        {
+            code: 'unknown',
+            display: 'Unknown',
+        },
+    ],
+};
 
 export const valuesetEncounterStatusData: ValueSet = {
+    id: 'encounter-status',
+    resourceType: 'ValueSet',
+    name: 'EncounterStatus',
+    status: 'active',
     description:
         'Current state of the encounter. This is not the clinical state of the patient, but the state of the encounter itself.',
+    url: 'http://hl7.org/fhir/ValueSet/encounter-status-test',
     compose: {
         include: [
             {
-                system: 'http://hl7.org/fhir/encounter-status',
-                concept: [
-                    {
-                        code: 'planned',
-                        display: 'Planned',
-                    },
-                    {
-                        code: 'in-progress',
-                        display: 'In Progress',
-                    },
-                    {
-                        code: 'on-hold',
-                        display: 'On Hold',
-                    },
-                    {
-                        code: 'discharged',
-                        display: 'Discharged',
-                    },
-                    {
-                        code: 'finished',
-                        display: 'Finished',
-                    },
-                    {
-                        code: 'cancelled',
-                        display: 'Cancelled',
-                    },
-                    {
-                        code: 'entered-in-error',
-                        display: 'Entered in Error',
-                    },
-                    {
-                        code: 'unknown',
-                        display: 'Unknown',
-                    },
-                ],
+                system: 'http://hl7.org/fhir/encounter-status-test',
             },
         ],
     },
-    meta: {
-        lastUpdated: '2024-08-08T08:02:50.718168Z',
-        createdAt: '2024-08-08T07:42:10.155157Z',
-        versionId: '87',
-    },
-    publisher: 'HL7 (FHIR Project)',
-    name: 'EncounterStatus',
-    experimental: false,
-    resourceType: 'ValueSet',
-    title: 'Encounter Status',
-    status: 'active',
-    id: 'encounter-status',
-    url: 'http://hl7.org/fhir/ValueSet/encounter-status',
-    immutable: true,
-    version: '5.0.0',
-    contact: [
-        {
-            telecom: [
-                {
-                    value: 'http://hl7.org/fhir',
-                    system: 'url',
-                },
-            ],
-        },
-    ],
 };

--- a/src/services/valueset-expand.ts
+++ b/src/services/valueset-expand.ts
@@ -98,7 +98,7 @@ export async function expandFHIRValueSet(answerValueSet: string | undefined, sea
 
     const response: RemoteDataResult<ValueSetOption[]> = mapSuccess(
         await service<ValueSet>({
-            url: `ValueSet/$expand?url=${answerValueSet}`,
+            url: `/fhir/ValueSet/$expand?url=${answerValueSet}`,
             params: {
                 filter: searchText,
                 count: 50,

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -21,7 +21,7 @@ import {
 import { formatFHIRDateTime } from 'aidbox-react/lib/utils/date';
 import { withRootAccess, LoginService, getToken } from 'aidbox-react/lib/utils/tests';
 
-import { User, ValueSet } from '@beda.software/aidbox-types';
+import { CodeSystem, User, ValueSet } from '@beda.software/aidbox-types';
 import config from '@beda.software/emr-config';
 import { ensure, getReference } from '@beda.software/fhir-react';
 
@@ -143,10 +143,23 @@ export async function createEncounter(subject: Reference, participant: Participa
     );
 }
 
+export async function createCodeSystem(codeSystemData: Partial<CodeSystem>) {
+    return await service<CodeSystem>({
+        baseURL: config.baseURL,
+        url: `/fhir/CodeSystem/${codeSystemData.id ?? ''}`,
+        method: 'PUT',
+        data: {
+            resourceType: 'CodeSystem',
+            status: 'active',
+            ...codeSystemData,
+        },
+    });
+}
+
 export async function createValueSet(valueSetData: Partial<ValueSet>) {
     return await service<ValueSet>({
         baseURL: config.baseURL,
-        url: 'ValueSet',
+        url: `/fhir/ValueSet/${valueSetData.id ?? ''}`,
         method: 'PUT',
         data: {
             resourceType: 'ValueSet',


### PR DESCRIPTION
Since stable aidboxone:2507 local ValueSet expansion is again available at `/fhir/ValueSet`

Hybrid engine allows seamless expansion of local and remote value sets:

```
GET /fhir/ValueSet/$expand?url=http://hl7.org/fhir/ValueSet/medicationknowledge-package-type

GET /fhir/ValueSet/$expand?url=http://some-local.domain/ValueSet/custom-local-value-set
```