### PR TITLE
Add vertical alignment for record action buttons

### DIFF
--- a/src/uberComponents/ResourceListPage/styles.ts
+++ b/src/uberComponents/ResourceListPage/styles.ts
@@ -7,6 +7,7 @@ export const S = {
     Actions: styled.div`
         display: flex;
         gap: 8px 16px;
+        align-items: center;
 
         @media screen and (max-width: ${() => `${mobileWidth - 1}px`}) {
             gap: 2px 16px;


### PR DESCRIPTION
If add several record actions if different types (e.g questionnaire and custom) the alignment is broken

<img width="444" height="189" alt="Screenshot 2025-10-21 at 12 36 39" src="https://github.com/user-attachments/assets/d3bf57ed-7698-429f-b8ae-fbaed77824bf" />
