### PR TITLE
Handle different scenarios to override FHIR base URL

### DIFF
--- a/src/services/fhir.ts
+++ b/src/services/fhir.ts
@@ -3,15 +3,33 @@ import {
     axiosInstance,
     setInstanceToken,
     resetInstanceToken,
-    setInstanceBaseURL,
+    setInstanceBaseURL as setAidboxInstanceBaseURL,
 } from 'aidbox-react';
 import type { AxiosRequestConfig } from 'axios';
 
+import config from '@beda.software/emr-config';
 import { initServicesFromService } from '@beda.software/fhir-react';
 import { RemoteDataResult } from '@beda.software/remote-data';
 
+let fhirBaseURL: string | null = null;
+
+function setInstanceBaseURL(baseURL: string) {
+    fhirBaseURL = baseURL;
+}
+
+function getInstanceBaseURL() {
+    if (fhirBaseURL) {
+        return fhirBaseURL;
+    }
+    if (config.fhirBaseURL) {
+        return config.fhirBaseURL;
+    }
+
+    return axiosInstance.defaults.baseURL + '/fhir';
+}
+
 const fhirService = async <S = any, F = any>(config: AxiosRequestConfig): Promise<RemoteDataResult<S, F>> => {
-    return aidboxService({ ...config, baseURL: axiosInstance.defaults.baseURL + '/fhir' });
+    return aidboxService({ ...config, baseURL: getInstanceBaseURL() });
 };
 
 export const {
@@ -49,4 +67,11 @@ export const {
     service,
 } = initServicesFromService(fhirService);
 
-export { aidboxService, axiosInstance, setInstanceToken, resetInstanceToken, setInstanceBaseURL };
+export {
+    aidboxService,
+    axiosInstance,
+    setInstanceToken,
+    resetInstanceToken,
+    setInstanceBaseURL,
+    setAidboxInstanceBaseURL,
+};

--- a/src/services/initialize.ts
+++ b/src/services/initialize.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 import config from '@beda.software/emr-config';
-import { setInstanceBaseURL } from 'src/services/fhir';
+import { setAidboxInstanceBaseURL } from 'src/services/fhir';
 
 if (config.webSentryDSN) {
     Sentry.init({
@@ -12,4 +12,4 @@ if (config.webSentryDSN) {
     });
 }
 
-setInstanceBaseURL(config.baseURL);
+setAidboxInstanceBaseURL(config.baseURL);

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -22,7 +22,7 @@ import { login as loginService } from 'src/services/auth';
 import {
     axiosInstance,
     resetInstanceToken,
-    setInstanceBaseURL,
+    setAidboxInstanceBaseURL,
     aidboxSaveFHIRResource,
     createFHIRResource,
     saveFHIRResource,
@@ -245,7 +245,7 @@ export async function waitForAPIProcess<R>(props: WaitForAPIProcessProps<R>) {
 
 beforeAll(async () => {
     // vi.useFakeTimers();
-    setInstanceBaseURL('http://localhost:8080');
+    setAidboxInstanceBaseURL('http://localhost:8080');
 });
 
 let txId: string;


### PR DESCRIPTION
share setInstanceBaseURL method to override FHIR Base URL;
manage `fhirBaseURL` config param;
keep default behavior with `/fhir` path assignment.