### PR TITLE
Add Magic Search mcp server switch and url params

### DIFF
--- a/src/containers/MagicSearchPage/index.tsx
+++ b/src/containers/MagicSearchPage/index.tsx
@@ -1,14 +1,14 @@
 import { SearchOutlined } from '@ant-design/icons';
 import { t, Trans } from '@lingui/macro';
-import { Button, Input, Radio, Space } from 'antd';
+import { Button, Input, Radio } from 'antd';
 import type { ColumnsType } from 'antd/es/table/interface';
 import { Resource } from 'fhir/r4b';
 import fhirpath_r4_model from 'fhirpath/fhir-context/r4';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
-import { formatError, RenderRemoteData } from '@beda.software/fhir-react';
-import { isLoading, loading, notAsked, RemoteData } from '@beda.software/remote-data';
+import { formatError, RenderRemoteData, useService } from '@beda.software/fhir-react';
+import { isLoading, mapSuccess, success } from '@beda.software/remote-data';
 
 import { MagicSearchResponse, performMagicSearch, TableColumnConfig } from 'src/services';
 import { RecordType } from 'src/uberComponents/ResourceListPage/types.ts';
@@ -58,62 +58,44 @@ function buildDynamicColumns<R extends Resource>(columnConfigs: TableColumnConfi
     });
 }
 
+interface MagicSearchUIResponse {
+    result: MagicSearchResponse | null;
+}
+
 export function MagicSearchPage() {
-    const [response, setResponse] = useState<RemoteData<MagicSearchResponse>>(notAsked);
     const [searchQuery, setSearchQuery] = useState('');
     const [mcpServer, setMcpServer] = useState<'tx-tools' | 'semmatch'>('tx-tools');
 
     const navigate = useNavigate();
     const location = useLocation();
 
+    const urlParams = new URLSearchParams(location.search);
+    const urlPrompt = urlParams.get('prompt') ?? '';
+    const urlMcpServer = urlParams.get('mcpServer') === 'semmatch' ? 'semmatch' : 'tx-tools';
+
+    const [response] = useService<MagicSearchUIResponse>(async () => {
+        setSearchQuery(urlPrompt);
+        setMcpServer(urlMcpServer);
+
+        if (!urlPrompt) {
+            return Promise.resolve(success({ result: null }));
+        }
+
+        return mapSuccess(await performMagicSearch(urlPrompt, urlMcpServer), (data) => ({
+            result: data,
+        }));
+    }, [urlPrompt, urlMcpServer]);
+
     const isDataLoading = isLoading(response);
 
-    const lastFetchedRef = useRef<{ query: string; server: 'tx-tools' | 'semmatch' } | null>(null);
-
-    useEffect(() => {
-        const params = new URLSearchParams(location.search);
-        const query = params.get('query') ?? '';
-        const server = params.get('mcp_server') === 'semmatch' ? 'semmatch' : 'tx-tools';
-
-        setSearchQuery(query);
-        setMcpServer(server);
-
-        if (!query) {
-            lastFetchedRef.current = null;
-            setResponse(notAsked);
-            return;
-        }
-
-        if (
-            lastFetchedRef.current &&
-            lastFetchedRef.current.query === query &&
-            lastFetchedRef.current.server === server
-        ) {
-            return;
-        }
-
-        (async () => {
-            try {
-                setResponse(loading);
-                const data = await performMagicSearch(query, server);
-                lastFetchedRef.current = { query, server };
-                setResponse(data);
-            } catch (err) {
-                setResponse({ type: 'failure', error: err } as any);
-            }
-        })();
-    }, [location.search]);
-
-    const performSearch = (query: string, server: 'tx-tools' | 'semmatch') => {
+    const performSearch = (prompt: string, server: 'tx-tools' | 'semmatch') => {
         const params = new URLSearchParams();
-        params.set('query', query);
-        params.set('mcp_server', server);
+        params.set('prompt', prompt);
+        params.set('mcpServer', server);
         navigate({ pathname: location.pathname, search: params.toString() }, { replace: false });
 
-        setSearchQuery(query);
+        setSearchQuery(prompt);
         setMcpServer(server);
-
-        setResponse(loading);
     };
 
     const handleSearch = async () => {
@@ -132,41 +114,41 @@ export function MagicSearchPage() {
     return (
         <div>
             <div style={{ padding: '20px', maxWidth: '900px', margin: '0 auto' }}>
-                <div style={{ display: 'flex', gap: 20, alignItems: 'center' }}>
+                <div style={{ display: 'flex', gap: 15, alignItems: 'center' }}>
                     <div style={{ flex: 1 }}>
-                        <Space.Compact style={{ width: '100%' }}>
-                            <Input
-                                placeholder={t`Enter your search query`}
-                                value={searchQuery}
-                                onChange={(e) => setSearchQuery(e.target.value)}
-                                onKeyPress={handleKeyPress}
-                                size="large"
-                                disabled={isDataLoading}
-                            />
-                            <Button
-                                type="primary"
-                                icon={<SearchOutlined />}
-                                onClick={handleSearch}
-                                size="large"
-                                disabled={!searchQuery.trim() || isDataLoading}
-                                loading={isDataLoading}
-                            >
-                                {isDataLoading ? <Trans>Searching...</Trans> : <Trans>Search</Trans>}
-                            </Button>
-                        </Space.Compact>
+                        <Input
+                            placeholder={t`Enter your search query`}
+                            value={searchQuery}
+                            onChange={(e) => setSearchQuery(e.target.value)}
+                            onKeyPress={handleKeyPress}
+                            size="large"
+                            disabled={isDataLoading}
+                        />
                     </div>
-
                     <div>
                         <Radio.Group
                             value={mcpServer}
                             onChange={(e) => setMcpServer(e.target.value)}
                             optionType="button"
                             buttonStyle="solid"
+                            size="large"
                             disabled={isDataLoading}
                         >
                             <Radio.Button value="tx-tools">tx-tools</Radio.Button>
                             <Radio.Button value="semmatch">semmatch</Radio.Button>
                         </Radio.Group>
+                    </div>
+                    <div>
+                        <Button
+                            type="primary"
+                            icon={<SearchOutlined />}
+                            onClick={handleSearch}
+                            size="large"
+                            disabled={!searchQuery.trim() || isDataLoading}
+                            loading={isDataLoading}
+                        >
+                            {isDataLoading ? <Trans>Searching...</Trans> : <Trans>Search</Trans>}
+                        </Button>
                     </div>
                 </div>
             </div>
@@ -180,17 +162,21 @@ export function MagicSearchPage() {
                     </div>
                 )}
             >
-                {(data) => {
+                {({ result }) => {
+                    if (!result) {
+                        return <div></div>;
+                    }
+
                     const getTableColumns = (): ColumnsType<RecordType<Resource>> =>
-                        buildDynamicColumns<Resource>(data.tableColumns);
+                        buildDynamicColumns<Resource>(result.tableColumns);
 
                     return (
                         <ResourceListPageContent
-                            resourceType={data.resourceType as any}
+                            resourceType={result.resourceType as any}
                             searchParams={{
                                 _sort: '-_lastUpdated,_id',
                                 _count: 10,
-                                ...data.searchParams,
+                                ...result.searchParams,
                             }}
                             getTableColumns={getTableColumns}
                         />

--- a/src/services/magic-search.ts
+++ b/src/services/magic-search.ts
@@ -19,7 +19,7 @@ export async function performMagicSearch(prompt: string, mcpServer: 'tx-tools' |
     return await aiService<MagicSearchResponse>({
         url: `/magic-search`,
         method: 'POST',
-        data: { prompt, mcp_server: mcpServer },
+        data: { prompt, mcpServer: mcpServer },
         headers: {
             Authorization: `Bearer ${appToken}`,
         },


### PR DESCRIPTION
Added mcp server switch between tx-tools and semmatch and url params query and mcp_server to Magic Search
Now Magic Search performs search not directly by click on the "search" button, but by changing url params on the click and observing the url state