### PR TITLE
Add authType setting for code grant auth

### DIFF
--- a/contrib/emr-config/config.d.ts
+++ b/contrib/emr-config/config.d.ts
@@ -1,5 +1,9 @@
 declare const config: {
     clientId: string;
+
+    authType?: 'token' | 'code'; // Default: token
+
+    // authTokenPath and authClientRedirectURL are used for `code` authType
     authTokenPath?: string;
     authClientRedirectURL?: string;
 

--- a/src/containers/App/auth/CodeGrantAuth.tsx
+++ b/src/containers/App/auth/CodeGrantAuth.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { RenderRemoteData, useService } from '@beda.software/fhir-react';
-import { failure, FetchError, isSuccess } from '@beda.software/remote-data';
+import { failure, isSuccess } from '@beda.software/remote-data';
 
 import { Spinner } from 'src/components';
 import {
@@ -42,7 +42,7 @@ export function CodeGrantAuth() {
 
             return exchangeCodeResponse;
         } else {
-            return failure<FetchError>({ message: 'Auth Code is not provided' });
+            return failure({ error: 'invalid', error_description: 'Auth Code is not provided' });
         }
     });
 

--- a/src/containers/App/index.tsx
+++ b/src/containers/App/index.tsx
@@ -4,6 +4,7 @@ import { ReactElement, useContext, useEffect, useRef } from 'react';
 import { Route, BrowserRouter, Routes, Navigate, useLocation, useNavigate } from 'react-router-dom';
 
 import { User } from '@beda.software/aidbox-types';
+import config from '@beda.software/emr-config';
 import { RenderRemoteData, useService } from '@beda.software/fhir-react';
 import { RemoteDataResult, success } from '@beda.software/remote-data';
 
@@ -25,6 +26,7 @@ import { SignIn } from 'src/containers/SignIn';
 import { VideoCall } from 'src/containers/VideoCall';
 import { getToken, parseOAuthState, setToken } from 'src/services/auth';
 
+import { CodeGrantAuth } from './auth/CodeGrantAuth';
 import { DefaultUserWithNoRoles } from './DefaultUserWithNoRoles';
 import { restoreUserSession } from './utils';
 import { AidboxFormsBuilder } from '../AidboxFormsBuilder';
@@ -104,7 +106,7 @@ function AnonymousUserApp({ extra }: { extra?: ReactElement }) {
     return (
         <Routes>
             {extra}
-            <Route path="/auth" element={<Auth />} />
+            <Route path="/auth" element={config.authType === 'code' ? <CodeGrantAuth /> : <Auth />} />
             <Route path="/signin" element={<SignIn originPathName={originPathRef.current} />} />
             <Route path="/reset-password/:code" element={<SetPassword />} />
             <Route

--- a/src/containers/SignIn/index.tsx
+++ b/src/containers/SignIn/index.tsx
@@ -20,7 +20,7 @@ enum SignInService {
 function authorize(state?: OAuthState) {
     window.location.href = getAuthorizeUrl({
         authPath: 'auth/authorize',
-        params: new URLSearchParams({ client_id: config.clientId, response_type: 'token' }),
+        params: new URLSearchParams({ client_id: config.clientId, response_type: config.authType ?? 'token' }),
         state,
     });
 }


### PR DESCRIPTION
It allows to easily switch from implicit to authorization_code (more secure way that has better Aidbox support, e.g. aidbox + keycloak)

Just settings authType to code in config changes the way how:
- login link works
- /auth works