### PR TITLE
Add inactiveMapping to emr-config

### DIFF
--- a/contrib/emr-config/config.d.ts
+++ b/contrib/emr-config/config.d.ts
@@ -17,6 +17,11 @@ declare const config: {
     wearablesDataStreamService: string;
     metriportIdentifierSystem: string;
     aiAssistantServiceUrl: string;
+    inactiveMapping?: Record<string, {
+        searchField: string;
+        statusField: string;
+        value: any;
+    }>;
 };
 
 export default config;

--- a/src/services/fhir.ts
+++ b/src/services/fhir.ts
@@ -47,7 +47,7 @@ export const {
     getConcepts: aidboxGetConcepts,
     applyFHIRService: aidboxApplyFHIRService,
     applyFHIRServices: aidboxApplyFHIRServices,
-} = initServicesFromService(aidboxService);
+} = initServicesFromService(aidboxService, config.inactiveMapping);
 
 export const {
     createFHIRResource,
@@ -65,7 +65,7 @@ export const {
     applyFHIRService,
     applyFHIRServices,
     service,
-} = initServicesFromService(fhirService);
+} = initServicesFromService(fhirService, config.inactiveMapping);
 
 export {
     aidboxService,


### PR DESCRIPTION
inactiveMapping is map of resourceTypes and search params values. See [fhir-react documentation](https://github.com/beda-software/fhir-react/blob/master/README.md#service-initialization-and-inactive-mapping) for details