### PR TITLE
Update preadmission questionnaire: rename, fix widgets, add consent step

### DIFF
--- a/resources/init-seeds/Questionnaire/preadmission.yaml
+++ b/resources/init-seeds/Questionnaire/preadmission.yaml
@@ -1,7 +1,7 @@
 resourceType: Questionnaire
 id: preadmission
 name: preadmission
-title: Pre-Procedure Health Questionnaire Form
+title: New Patient Registration
 status: active
 subjectType:
   - Patient
@@ -428,17 +428,11 @@ item:
       - linkId: person-to-contact-group
         text: Person to Contact
         type: group
-        itemControl:
-          coding:
-            - code: group-table
         item:
           - linkId: person-to-contact-item
             text: Contact
             type: group
             repeats: true
-            itemControl:
-              coding:
-                - code: group-table
             item:
               - linkId: contact-given-name
                 text: Given Name
@@ -491,6 +485,52 @@ item:
                 itemControl:
                   coding:
                     - code: phoneWidget
-                # initialExpression:
-                #   language: text/fhirpath
-                #   expression: "'+61 '"
+                initialExpression:
+                  language: text/fhirpath
+                  expression: "'+61 '"
+
+      # Consent step
+      - linkId: consent-group
+        text: Privacy and Terms
+        type: group
+        item:
+          - linkId: consent-description
+            type: display
+            itemControl:
+              coding:
+                - code: markdown
+            text: |
+              We are committed to protecting the confidentiality of your personal information and health
+              records. In submitting this form, you:
+
+              1. acknowledge that we, and our service providers, will collect your personal and health
+              information to enable us to provide you with our health services and any related
+              communications (for example, to manage your appointment bookings); and
+
+              2. consent to our handling of your personal information in accordance with our Privacy
+              Policy (you can access our Privacy Policy on our website, or by asking us for a copy).
+
+          - linkId: consent-agreement
+            text: Do you agree to the terms?
+            type: choice
+            required: true
+            itemControl:
+              coding:
+                - code: inline-choice
+            answerOption:
+              - valueCoding:
+                  system: http://terminology.hl7.org/CodeSystem/v2-0136
+                  code: "Y"
+                  display: "Yes"
+              - valueCoding:
+                  system: http://terminology.hl7.org/CodeSystem/v2-0136
+                  code: "N"
+                  display: "No"
+            itemConstraint:
+            - key: consent-agreement-required
+              requirements: You need to agree to the terms
+              severity: error
+              human: You need to agree to the terms
+              expression: >-
+                  %QuestionnaireResponse.repeat(item).where(linkId='consent-agreement').answer.valueCoding.code = 'Y'
+


### PR DESCRIPTION
**Ref:** https://github.com/beda-software/fhir-emr/issues/796

Refactor preadmission questionnaire:

- Rename to **New Patient Registration**
- Change **Person to Contact** from group-table to regular group
- Add **Privacy and Terms** consent step

**Consent implementation notes:**
- Used choice type (Yes/No) instead of boolean because required validation
  is not supported for boolean fields in our renderer
- Added itemConstraint to enforce "Yes" selection - standard `required: true`
  only checks that any answer is selected, not the specific value
  
  
<img width="1146" height="644" alt="Screenshot 2026-05-11 at 23 08 33" src="https://github.com/user-attachments/assets/b8216a5b-6195-473c-946b-1702328c4706" />
