### PR TITLE
Horizontal wizard: child-registration & preadmission

### DIFF
--- a/resources/init-seeds/Questionnaire/child-registration.yaml
+++ b/resources/init-seeds/Questionnaire/child-registration.yaml
@@ -44,7 +44,7 @@ item:
     type: group
     itemControl:
       coding:
-        - code: wizard-vertical
+        - code: wizard
     item:
       - linkId: child-information
         text: Child Information

--- a/resources/init-seeds/Questionnaire/preadmission.yaml
+++ b/resources/init-seeds/Questionnaire/preadmission.yaml
@@ -45,7 +45,7 @@ item:
     type: group
     itemControl:
       coding:
-        - code: wizard-vertical
+        - code: wizard
     item:
       # Header
       - linkId: instructions


### PR DESCRIPTION
**Summary**

`child-registration.yaml` and `preadmission.yaml`: `wizard-vertical` → `wizard` on the root wizard group (horizontal stepper).