### PR TITLE
fix(questionnaire): add library category to pre-visit-intake seed

### DIFF
--- a/resources/init-seeds/Questionnaire/pre-visit-intake.yaml
+++ b/resources/init-seeds/Questionnaire/pre-visit-intake.yaml
@@ -20,6 +20,14 @@ useContext:
       CodeableConcept:
         coding:
           - code: form-library
+  - code:
+      code: category
+      system: https://beda.software/FHIR/CodeSystem/questionnaire-category
+    value:
+      CodeableConcept:
+        coding:
+          - code: common
+            system: https://beda.software/FHIR/CodeSystem/questionnaire-category
 launchContext:
   - name:
       code: Patient


### PR DESCRIPTION
Adds a `useContext` entry with `questionnaire-category` **`common`** to the pre-visit intake Questionnaire seed, alongside the existing `form-library` type.