### PR TITLE
update fhir-sdc to 2.1.0a1

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -22,7 +22,7 @@ services:
     env_file:
       - ./env/sdc-ide
   sdc:
-    image: bedasoftware/fhir-sdc:1.0.0a14
+    image: bedasoftware/fhir-sdc:2.1.0a1
     depends_on:
       devbox-healthcheck:
         condition: service_healthy
@@ -207,11 +207,3 @@ services:
       interval: 5s
       timeout: 30s
       retries: 50
-
-  fhir-converters-app:
-    image: bedasoftware/aidbox-fhir-converter:main
-    depends_on:
-      devbox-healthcheck:
-        condition: service_healthy
-    env_file:
-      - ./env/fhir-converters-app

--- a/env/fhir-converters-app
+++ b/env/fhir-converters-app
@@ -1,8 +1,0 @@
-APP_ID=fhir-converters-app
-APP_SECRET=secret
-APP_URL=http://fhir-converters-app:3000
-APP_PORT=3000
-
-AIDBOX_CLIENT_ID=root
-AIDBOX_CLIENT_SECRET=secret
-AIDBOX_URL=http://devbox:8080

--- a/env/sdc
+++ b/env/sdc
@@ -1,7 +1,6 @@
 APP_INIT_CLIENT_ID=root
 APP_INIT_CLIENT_SECRET=secret
 APP_INIT_URL=http://devbox:8080
-BASE_URL=http://devbox:8080/fhir
 
 APP_ID=sdc
 APP_SECRET=secret

--- a/env/sdc
+++ b/env/sdc
@@ -1,6 +1,7 @@
 APP_INIT_CLIENT_ID=root
 APP_INIT_CLIENT_SECRET=secret
 APP_INIT_URL=http://devbox:8080
+BASE_URL=http://devbox:8080/fhir
 
 APP_ID=sdc
 APP_SECRET=secret


### PR DESCRIPTION
NOTE: fhir-converters-app removed as obsolete with new fhir-sdc