### PR TITLE
Fix patient document questionnaire canonical link and title lookup

### DIFF
--- a/src/containers/DocumentsList/hooks.ts
+++ b/src/containers/DocumentsList/hooks.ts
@@ -40,9 +40,15 @@ export function usePatientDocuments(patient: Patient, encounter?: Reference, con
             return mapSuccess(qResponse, (bundle) => {
                 const questionnaireNames: { [key: string]: string } = {};
                 const questionnaireNameById: { [key: string]: string } = {};
-                extractBundleResources(bundle).Questionnaire.forEach(
-                    (q) => (questionnaireNameById[q.id!] = q.title || q.name || t`Unknown`),
-                );
+                extractBundleResources(bundle).Questionnaire.forEach((q) => {
+                    const title = q.title || q.name || t`Unknown`;
+                    if (q.url) {
+                        questionnaireNameById[q.url] = title;
+                    }
+                    if (q.id) {
+                        questionnaireNameById[q.id] = title;
+                    }
+                });
 
                 qrResponseExtracted.data.QuestionnaireResponse.forEach((qr) => {
                     const remoteName = questionnaireNameById[qr.questionnaire!];

--- a/src/containers/PatientDetails/PatientDocument/usePatientDocument.ts
+++ b/src/containers/PatientDetails/PatientDocument/usePatientDocument.ts
@@ -62,7 +62,7 @@ async function onFormSubmit(
     const modifiedFormData = _.merge({}, formData, {
         context: {
             questionnaireResponse: {
-                questionnaire: initialQuestionnaireResponse?.questionnaire,
+                questionnaire: formData.context.questionnaire.url ?? initialQuestionnaireResponse?.questionnaire,
             },
         },
     });


### PR DESCRIPTION
## Summary

- **Save amended documents with canonical questionnaire link**: on submit, prefer `formData.context.questionnaire.url` over the previous `QuestionnaireResponse.questionnaire` value (which could be a resource id).
- **Documents list title lookup**: index loaded `Questionnaire` titles by both `url` and `id`, so legacy responses still show the correct name instead of **Unknown**.

## Context

After amend/save, `QuestionnaireResponse.questionnaire` could store the Aidbox resource id (e.g. `curated-ips`) while the questionnaire canonical `url` differs (e.g. `ips-curated-questionnaire`). The documents table looked up titles only by one key, so the name was lost.

## Test plan

- [x] Patient → Documents → create IPS (or any patient document)
- [x] Save → list shows questionnaire **title**, not Unknown
- [x] Open document → amend → save again → title still correct
- [x] Existing QR with `questionnaire` = id only → title still resolves if Questionnaire is loaded
