### PR TITLE
fix(ResourceListPage): compose qrfProps onSuccess/onCancel with modal close

### DIFF
--- a/src/uberComponents/ResourceListPage/actions.tsx
+++ b/src/uberComponents/ResourceListPage/actions.tsx
@@ -57,16 +57,20 @@ export function RecordQuestionnaireAction<R extends Resource>({
                         ...defaultLaunchContext,
                         { name: resource.resourceType, resource: resource as any },
                     ]}
-                    onSuccess={() => {
+                    saveButtonTitle={t`Submit`}
+                    {...(action.extra?.qrfProps ?? {})}
+                    onSuccess={(response) => {
                         notification.success({
                             message: t`Successfully submitted`,
                         });
                         reload();
                         closeModal();
+                        action.extra?.qrfProps?.onSuccess?.(response);
                     }}
-                    onCancel={closeModal}
-                    saveButtonTitle={t`Submit`}
-                    {...(action.extra?.qrfProps ?? {})}
+                    onCancel={() => {
+                        closeModal();
+                        action.extra?.qrfProps?.onCancel?.();
+                    }}
                 />
             )}
         </ModalTrigger>
@@ -93,15 +97,19 @@ export function HeaderQuestionnaireAction({ action, reload, defaultLaunchContext
             {({ closeModal }) => (
                 <QuestionnaireResponseForm
                     questionnaireLoader={questionnaireIdLoader(action.questionnaireId)}
-                    onSuccess={() => {
+                    launchContextParameters={defaultLaunchContext}
+                    saveButtonTitle={t`Submit`}
+                    {...(action.extra?.qrfProps ?? {})}
+                    onSuccess={(response) => {
                         closeModal();
                         notification.success({ message: t`Successfully submitted` });
                         reload();
+                        action.extra?.qrfProps?.onSuccess?.(response);
                     }}
-                    launchContextParameters={defaultLaunchContext}
-                    onCancel={closeModal}
-                    saveButtonTitle={t`Submit`}
-                    {...(action.extra?.qrfProps ?? {})}
+                    onCancel={() => {
+                        closeModal();
+                        action.extra?.qrfProps?.onCancel?.();
+                    }}
                 />
             )}
         </ModalTrigger>
@@ -143,14 +151,18 @@ export function BatchQuestionnaireAction<R extends Resource>({
                                 resource: bundle as Bundle,
                             },
                         ]}
-                        onSuccess={() => {
+                        saveButtonTitle={t`Submit`}
+                        {...(action.extra?.qrfProps ? omit(action.extra?.qrfProps, 'launchContextParameters') : {})}
+                        onSuccess={(response) => {
                             closeModal();
                             notification.success({ message: t`Successfully submitted` });
                             reload();
+                            action.extra?.qrfProps?.onSuccess?.(response);
                         }}
-                        onCancel={closeModal}
-                        saveButtonTitle={t`Submit`}
-                        {...(action.extra?.qrfProps ? omit(action.extra?.qrfProps, 'launchContextParameters') : {})}
+                        onCancel={() => {
+                            closeModal();
+                            action.extra?.qrfProps?.onCancel?.();
+                        }}
                     />
                 )}
             </ModalTrigger>

--- a/src/uberComponents/ResourceListPage/actions.tsx
+++ b/src/uberComponents/ResourceListPage/actions.tsx
@@ -60,9 +60,11 @@ export function RecordQuestionnaireAction<R extends Resource>({
                     saveButtonTitle={t`Submit`}
                     {...(action.extra?.qrfProps ?? {})}
                     onSuccess={(response) => {
-                        notification.success({
-                            message: t`Successfully submitted`,
-                        });
+                        if (!action.extra?.qrfProps?.onSuccess) {
+                            notification.success({
+                                message: t`Successfully submitted`,
+                            });
+                        }
                         reload();
                         action.extra?.qrfProps?.onSuccess?.(response);
                         closeModal();
@@ -101,7 +103,9 @@ export function HeaderQuestionnaireAction({ action, reload, defaultLaunchContext
                     saveButtonTitle={t`Submit`}
                     {...(action.extra?.qrfProps ?? {})}
                     onSuccess={(response) => {
-                        notification.success({ message: t`Successfully submitted` });
+                        if (!action.extra?.qrfProps?.onSuccess) {
+                            notification.success({ message: t`Successfully submitted` });
+                        }
                         reload();
                         action.extra?.qrfProps?.onSuccess?.(response);
                         closeModal();
@@ -154,7 +158,9 @@ export function BatchQuestionnaireAction<R extends Resource>({
                         saveButtonTitle={t`Submit`}
                         {...(action.extra?.qrfProps ? omit(action.extra?.qrfProps, 'launchContextParameters') : {})}
                         onSuccess={(response) => {
-                            notification.success({ message: t`Successfully submitted` });
+                            if (!action.extra?.qrfProps?.onSuccess) {
+                                notification.success({ message: t`Successfully submitted` });
+                            }
                             reload();
                             action.extra?.qrfProps?.onSuccess?.(response);
                             closeModal();

--- a/src/uberComponents/ResourceListPage/actions.tsx
+++ b/src/uberComponents/ResourceListPage/actions.tsx
@@ -64,12 +64,12 @@ export function RecordQuestionnaireAction<R extends Resource>({
                             message: t`Successfully submitted`,
                         });
                         reload();
-                        closeModal();
                         action.extra?.qrfProps?.onSuccess?.(response);
+                        closeModal();
                     }}
                     onCancel={() => {
-                        closeModal();
                         action.extra?.qrfProps?.onCancel?.();
+                        closeModal();
                     }}
                 />
             )}
@@ -101,14 +101,14 @@ export function HeaderQuestionnaireAction({ action, reload, defaultLaunchContext
                     saveButtonTitle={t`Submit`}
                     {...(action.extra?.qrfProps ?? {})}
                     onSuccess={(response) => {
-                        closeModal();
                         notification.success({ message: t`Successfully submitted` });
                         reload();
                         action.extra?.qrfProps?.onSuccess?.(response);
+                        closeModal();
                     }}
                     onCancel={() => {
-                        closeModal();
                         action.extra?.qrfProps?.onCancel?.();
+                        closeModal();
                     }}
                 />
             )}
@@ -154,14 +154,14 @@ export function BatchQuestionnaireAction<R extends Resource>({
                         saveButtonTitle={t`Submit`}
                         {...(action.extra?.qrfProps ? omit(action.extra?.qrfProps, 'launchContextParameters') : {})}
                         onSuccess={(response) => {
-                            closeModal();
                             notification.success({ message: t`Successfully submitted` });
                             reload();
                             action.extra?.qrfProps?.onSuccess?.(response);
+                            closeModal();
                         }}
                         onCancel={() => {
-                            closeModal();
                             action.extra?.qrfProps?.onCancel?.();
+                            closeModal();
                         }}
                     />
                 )}


### PR DESCRIPTION
## Summary
- Keep ResourceListPage questionnaire modal close/reload/notification behavior when `qrfProps.onSuccess` or `qrfProps.onCancel` are provided
- Compose consumer callbacks with built-in handlers in header, record, and batch questionnaire actions
- Unified handler order: notify → reload → consumer `onSuccess` → close modal; consumer `onCancel` → close modal

## Behavior notes
- **API semantics:** `extra.qrfProps.onSuccess` / `onCancel` are now additive, not overrides. Built-in behavior (success notification, list reload, modal close) always runs; consumer callbacks run in addition. Downstream code that previously replaced these handlers to skip notification, skip reload, or keep the modal open will need to adjust.