### PR TITLE
fix(QRF): restore default antd notifications after save

### DIFF
--- a/src/components/QuestionnaireResponseForm/components.tsx
+++ b/src/components/QuestionnaireResponseForm/components.tsx
@@ -32,6 +32,7 @@ import { FormWrapper, GroupItemComponent, ReadonlyFormWrapper } from 'src/compon
 import { service } from 'src/services';
 
 import { QuestionnaireResponseFormProps } from './types';
+import { withFormResponseHandlers } from './utils';
 
 export function QuestionnaireResponseForm({
     onCancel,
@@ -103,13 +104,15 @@ export function QuestionnaireResponseForm({
               }
             : undefined);
 
+    const formResponseHandlers = withFormResponseHandlers({ onSuccess, onFailure });
+
     return (
         <FHIRQuestionnaireResponseForm
             questionnaireLoader={questionnaireLoader}
             initialQuestionnaireResponse={initialQuestionnaireResponse}
             launchContextParameters={launchContextParameters}
-            onSuccess={onSuccess as Props['onSuccess']}
-            onFailure={onFailure}
+            onSuccess={formResponseHandlers.onSuccess}
+            onFailure={formResponseHandlers.onFailure}
             readOnly={readOnly}
             customYupTests={customYupTests}
             serviceProvider={serviceProviderProp ?? { service }}

--- a/src/components/QuestionnaireResponseForm/hooks.ts
+++ b/src/components/QuestionnaireResponseForm/hooks.ts
@@ -9,10 +9,18 @@ import { FormWrapper, GroupItemComponent } from 'src/components/FormWrapper';
 import { service } from 'src/services';
 
 import { QuestionnaireResponseFormProps } from './types';
+import { withFormResponseHandlers } from './utils';
 
 export function useQuestionnaireResponseForm(props: QuestionnaireResponseFormProps) {
+    const { onSuccess, onFailure } = withFormResponseHandlers({
+        onSuccess: props.onSuccess,
+        onFailure: props.onFailure,
+    });
+
     return useFHIRQuestionnaireResponseForm({
         ...props,
+        onSuccess,
+        onFailure,
         serviceProvider: props.serviceProvider ?? {
             service,
         },

--- a/src/components/QuestionnaireResponseForm/utils.tsx
+++ b/src/components/QuestionnaireResponseForm/utils.tsx
@@ -9,53 +9,82 @@ import {
     QuestionnaireResponseFormSaveResponseFailure,
 } from 'src/hooks/questionnaire-response-form-data';
 
+export function notifyExtractionWarnings(response: QuestionnaireResponseFormSaveResponse) {
+    const warnings: string[] = [];
+
+    response.extractedBundle.forEach((bundle, index) => {
+        bundle.entry?.forEach((entry, jndex) => {
+            if (entry.resource?.resourceType === 'OperationOutcome') {
+                warnings.push(`Error extracting on ${index}, ${jndex}`);
+            }
+        });
+    });
+
+    if (warnings.length === 0) {
+        return;
+    }
+
+    notification.warning({
+        message: (
+            <div>
+                {warnings.map((w) => (
+                    <div key={w}>
+                        <span>{w}</span>
+                        <br />
+                    </div>
+                ))}
+            </div>
+        ),
+    });
+}
+
+export function notifyFormFailure(error: any) {
+    // `@beda.software/fhir-questionnaire` reports save failures either as
+    // `{ extractedError: OperationOutcome }` or as a plain string message.
+    const failureError = error?.extractedError ?? error;
+
+    notification.error({
+        message: typeof failureError === 'string' ? failureError : formatError(failureError),
+    });
+}
+
+/**
+ * Default antd notifications for questionnaire submit results. A caller-provided
+ * `onSuccess`/`onFailure` replaces the corresponding notification.
+ */
+export function withFormResponseHandlers(props: {
+    onSuccess?: (resource: QuestionnaireResponseFormSaveResponse) => void;
+    onFailure?: (error: any) => void;
+}) {
+    const { onSuccess, onFailure } = props;
+
+    return {
+        onSuccess: (response: QuestionnaireResponseFormSaveResponse) => {
+            notifyExtractionWarnings(response);
+
+            if (onSuccess) {
+                onSuccess(response);
+            } else {
+                notification.success({ message: t`Form successfully saved` });
+            }
+        },
+        onFailure: onFailure ?? notifyFormFailure,
+    };
+}
+
 export function onFormResponse(props: {
     response: RemoteDataResult<QuestionnaireResponseFormSaveResponse, QuestionnaireResponseFormSaveResponseFailure>;
     onSuccess?: (resource: QuestionnaireResponseFormSaveResponse) => void;
     onFailure?: (error: QuestionnaireResponseFormSaveResponseFailure) => void;
 }) {
     const { response, onSuccess, onFailure } = props;
+    const handlers = withFormResponseHandlers({ onSuccess, onFailure });
 
     if (isSuccess(response)) {
         if (response.data.extracted) {
-            const warnings: string[] = [];
-            response.data.extractedBundle.forEach((bundle, index) => {
-                bundle.entry?.forEach((entry, jndex) => {
-                    if (entry.resource?.resourceType === 'OperationOutcome') {
-                        warnings.push(`Error extracting on ${index}, ${jndex}`);
-                    }
-                });
-            });
-            if (warnings.length > 0) {
-                notification.warning({
-                    message: (
-                        <div>
-                            {warnings.map((w) => (
-                                <div key={w}>
-                                    <span>{w}</span>
-                                    <br />
-                                </div>
-                            ))}
-                        </div>
-                    ),
-                });
-            }
-
-            if (onSuccess) {
-                onSuccess(response.data);
-            } else {
-                notification.success({
-                    message: t`Form successfully saved`,
-                });
-            }
+            handlers.onSuccess(response.data);
         }
     } else {
-        if (onFailure) {
-            onFailure(response.error);
-        } else {
-            if (response.error.extractedError) {
-                notification.error({ message: formatError(response.error.extractedError) });
-            }
-        }
+        handlers.onFailure(response.error);
     }
 }


### PR DESCRIPTION
## Summary
- After migrating QuestionnaireResponseForm to `@beda.software/fhir-questionnaire`, submit failures (e.g. `$constraint-check`) no longer showed antd error notifications because the package only invokes optional `onSuccess`/`onFailure` callbacks.
- Restore EMR default notifications by wrapping those callbacks with `withFormResponseHandlers` in both QRF entry points (`QuestionnaireResponseForm` and `useQuestionnaireResponseForm`).
- Keep `onFormResponse` for existing callers (e.g. PatientDocument) and have it share the same notification helpers.
