### PR TITLE
Support questionnaire translations via locale-aware QRF

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "@ant-design/colors": "^7.0.0",
         "@ant-design/icons": "^5.1.4",
         "@beda.software/emr-config": "*",
-        "@beda.software/fhir-questionnaire": "^0.1.0-alpha.13",
+        "@beda.software/fhir-questionnaire": "^0.1.0-alpha.15",
         "@beda.software/fhir-react": "^1.11.0",
         "@beda.software/remote-data": "^1.1.4",
         "@beda.software/web-item-controls": "^0.1.22",
@@ -73,7 +73,7 @@
         "remark-directive": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "sass": "^1.63.6",
-        "sdc-qrf": "^1.1.0-alpha.11",
+        "sdc-qrf": "^1.1.0-alpha.13",
         "styled-components": "^6.1.11",
         "yup": "^1.7.0"
     },

--- a/resources/init-seeds/Questionnaire/encounter-create/encounter-create.de.yaml
+++ b/resources/init-seeds/Questionnaire/encounter-create/encounter-create.de.yaml
@@ -1,0 +1,30 @@
+id: encounter-create.de
+resourceType: Questionnaire
+url: https://aidbox.emr.beda.software/fhir/Questionnaire/encounter-create
+language: de
+status: active
+title: Encounter erstellen
+description: Erstellt eine neue klinische Begegnung.
+item:
+  - text: Patienten-ID
+    type: string
+    linkId: patientId
+  - text: Patientenname
+    type: string
+    linkId: patientName
+  - text: Behandler
+    type: reference
+    linkId: practitioner-role
+  - text: Leistung
+    type: choice
+    linkId: service
+    answerOption:
+      - valueCoding:
+          code: consultation
+          display: Der erste Termin
+      - valueCoding:
+          code: follow-up
+          display: Ein Folgetermin
+  - text: Datum
+    type: dateTime
+    linkId: date

--- a/resources/init-seeds/Questionnaire/encounter-create/encounter-create.es.yaml
+++ b/resources/init-seeds/Questionnaire/encounter-create/encounter-create.es.yaml
@@ -1,0 +1,31 @@
+id: encounter-create.es
+resourceType: Questionnaire
+url: https://aidbox.emr.beda.software/fhir/Questionnaire/encounter-create
+language: es
+status: active
+title: Crear encuentro
+description: Crea un nuevo encuentro clínico.
+item:
+  - text: Id del paciente
+    type: string
+    linkId: patientId
+  - text: Nombre del paciente
+    type: string
+    linkId: patientName
+  - text: Profesional
+    type: reference
+    linkId: practitioner-role
+  - text: Servicio
+    type: choice
+    linkId: service
+    answerOption:
+      - valueCoding:
+          code: consultation
+          display: La primera cita
+      - valueCoding:
+          code: follow-up
+          display: Una visita de seguimiento
+  - text: Fecha
+    type: dateTime
+    linkId: date
+

--- a/resources/init-seeds/Questionnaire/encounter-create/encounter-create.yaml
+++ b/resources/init-seeds/Questionnaire/encounter-create/encounter-create.yaml
@@ -1,6 +1,7 @@
 id: encounter-create
 resourceType: Questionnaire
 name: encounter-create
+language: en
 title: Encounter create
 status: active
 description: Creates a new clinical encounter.
@@ -19,7 +20,7 @@ item:
     initialExpression:
       language: text/fhirpath
       expression: "%Patient.id"
-  - text: PatientName
+  - text: Patient Name
     type: string
     linkId: patientName
     readOnly: true

--- a/resources/init-seeds/Questionnaire/gad-7.yaml
+++ b/resources/init-seeds/Questionnaire/gad-7.yaml
@@ -2,8 +2,16 @@ id: gad-7
 resourceType: Questionnaire
 name: gad-7
 title: GAD-7
+_title:
+  translation:
+    - lang: es
+      content: GAD-7
 status: active
 description: Generalised Anxiety Disorder 7-item scale; screens severity of anxiety symptoms over the past two weeks.
+_description:
+  translation:
+    - lang: es
+      content: Escala de 7 ítems del Trastorno de Ansiedad Generalizada; evalúa la gravedad de los síntomas de ansiedad durante las últimas dos semanas.
 subjectType:
   - Encounter
   - Patient
@@ -63,6 +71,10 @@ item:
       expression: "%Patient.name.first().given.first() + ' ' + %Patient.name.first().family"
 
   - text: Over the last two weeks, how often have you been bothered by the following problems?
+    _text:
+      translation:
+        - lang: es
+          content: Durante las últimas 2 semanas, ¿qué tan seguido ha tenido molestias debido a los siguientes problemas?
     type: group
     itemControl:
       coding:
@@ -71,6 +83,10 @@ item:
     item:
       - linkId: 69725-0
         text: Feeling nervous, anxious, or on edge
+        _text:
+          translation:
+            - lang: es
+              content: Se ha sentido nervioso(a), ansioso(a) o con los nervios de punta
         required: true
         type: choice
         itemControl:
@@ -81,6 +97,10 @@ item:
               system: "http://loinc.org"
               code: "LA6568-5"
               display: "Not at all"
+              _display:
+                translation:
+                  - lang: es
+                    content: Ningún día
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 0
@@ -88,6 +108,10 @@ item:
               system: "http://loinc.org"
               code: "LA6569-3"
               display: "Several days"
+              _display:
+                translation:
+                  - lang: es
+                    content: Varios días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 1
@@ -95,6 +119,10 @@ item:
               system: "http://loinc.org"
               code: "LA6570-1"
               display: "More than half the days"
+              _display:
+                translation:
+                  - lang: es
+                    content: Más de la mitad de los días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 2
@@ -102,12 +130,20 @@ item:
               system: "http://loinc.org"
               code: "LA6571-9"
               display: "Nearly every day"
+              _display:
+                translation:
+                  - lang: es
+                    content: Casi todos los días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 3
 
       - linkId: 68509-9
         text: Not being able to stop or control worrying
+        _text:
+          translation:
+            - lang: es
+              content: No ha sido capaz de parar o controlar su preocupación
         required: true
         type: choice
         itemControl:
@@ -118,6 +154,10 @@ item:
               system: "http://loinc.org"
               code: "LA6568-5"
               display: "Not at all"
+              _display:
+                translation:
+                  - lang: es
+                    content: Ningún día
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 0
@@ -125,6 +165,10 @@ item:
               system: "http://loinc.org"
               code: "LA6569-3"
               display: "Several days"
+              _display:
+                translation:
+                  - lang: es
+                    content: Varios días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 1
@@ -132,6 +176,10 @@ item:
               system: "http://loinc.org"
               code: "LA6570-1"
               display: "More than half the days"
+              _display:
+                translation:
+                  - lang: es
+                    content: Más de la mitad de los días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 2
@@ -139,12 +187,20 @@ item:
               system: "http://loinc.org"
               code: "LA6571-9"
               display: "Nearly every day"
+              _display:
+                translation:
+                  - lang: es
+                    content: Casi todos los días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 3
 
       - linkId: 69733-4
         text: Worrying too much about different things
+        _text:
+          translation:
+            - lang: es
+              content: Se ha preocupado demasiado por motivos diferentes
         required: true
         type: choice
         itemControl:
@@ -155,6 +211,10 @@ item:
               system: "http://loinc.org"
               code: "LA6568-5"
               display: "Not at all"
+              _display:
+                translation:
+                  - lang: es
+                    content: Ningún día
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 0
@@ -162,6 +222,10 @@ item:
               system: "http://loinc.org"
               code: "LA6569-3"
               display: "Several days"
+              _display:
+                translation:
+                  - lang: es
+                    content: Varios días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 1
@@ -169,6 +233,10 @@ item:
               system: "http://loinc.org"
               code: "LA6570-1"
               display: "More than half the days"
+              _display:
+                translation:
+                  - lang: es
+                    content: Más de la mitad de los días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 2
@@ -176,12 +244,20 @@ item:
               system: "http://loinc.org"
               code: "LA6571-9"
               display: "Nearly every day"
+              _display:
+                translation:
+                  - lang: es
+                    content: Casi todos los días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 3
 
       - linkId: 69734-2
         text: Trouble relaxing
+        _text:
+          translation:
+            - lang: es
+              content: Ha tenido dificultad para relajarse
         required: true
         type: choice
         itemControl:
@@ -192,6 +268,10 @@ item:
               system: "http://loinc.org"
               code: "LA6568-5"
               display: "Not at all"
+              _display:
+                translation:
+                  - lang: es
+                    content: Ningún día
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 0
@@ -199,6 +279,10 @@ item:
               system: "http://loinc.org"
               code: "LA6569-3"
               display: "Several days"
+              _display:
+                translation:
+                  - lang: es
+                    content: Varios días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 1
@@ -206,6 +290,10 @@ item:
               system: "http://loinc.org"
               code: "LA6570-1"
               display: "More than half the days"
+              _display:
+                translation:
+                  - lang: es
+                    content: Más de la mitad de los días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 2
@@ -213,12 +301,20 @@ item:
               system: "http://loinc.org"
               code: "LA6571-9"
               display: "Nearly every day"
+              _display:
+                translation:
+                  - lang: es
+                    content: Casi todos los días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 3
 
       - linkId: 69735-9
         text: Being so restless that it is hard to sit still
+        _text:
+          translation:
+            - lang: es
+              content: Se ha sentido tan inquieto(a) que no ha podido quedarse quieto(a)
         required: true
         type: choice
         itemControl:
@@ -229,6 +325,10 @@ item:
               system: "http://loinc.org"
               code: "LA6568-5"
               display: "Not at all"
+              _display:
+                translation:
+                  - lang: es
+                    content: Ningún día
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 0
@@ -236,6 +336,10 @@ item:
               system: "http://loinc.org"
               code: "LA6569-3"
               display: "Several days"
+              _display:
+                translation:
+                  - lang: es
+                    content: Varios días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 1
@@ -243,6 +347,10 @@ item:
               system: "http://loinc.org"
               code: "LA6570-1"
               display: "More than half the days"
+              _display:
+                translation:
+                  - lang: es
+                    content: Más de la mitad de los días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 2
@@ -250,12 +358,20 @@ item:
               system: "http://loinc.org"
               code: "LA6571-9"
               display: "Nearly every day"
+              _display:
+                translation:
+                  - lang: es
+                    content: Casi todos los días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 3
 
       - linkId: 69689-8
         text: Becoming easily annoyed or irritable
+        _text:
+          translation:
+            - lang: es
+              content: Se ha molestado o irritado fácilmente
         required: true
         type: choice
         itemControl:
@@ -266,6 +382,10 @@ item:
               system: "http://loinc.org"
               code: "LA6568-5"
               display: "Not at all"
+              _display:
+                translation:
+                  - lang: es
+                    content: Ningún día
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 0
@@ -273,6 +393,10 @@ item:
               system: "http://loinc.org"
               code: "LA6569-3"
               display: "Several days"
+              _display:
+                translation:
+                  - lang: es
+                    content: Varios días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 1
@@ -280,6 +404,10 @@ item:
               system: "http://loinc.org"
               code: "LA6570-1"
               display: "More than half the days"
+              _display:
+                translation:
+                  - lang: es
+                    content: Más de la mitad de los días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 2
@@ -287,12 +415,20 @@ item:
               system: "http://loinc.org"
               code: "LA6571-9"
               display: "Nearly every day"
+              _display:
+                translation:
+                  - lang: es
+                    content: Casi todos los días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 3
 
       - linkId: 69736-7
         text: Feeling afraid, as if something awful might happen
+        _text:
+          translation:
+            - lang: es
+              content: Ha tenido miedo de que algo terrible fuera a pasar
         required: true
         type: choice
         itemControl:
@@ -303,6 +439,10 @@ item:
               system: "http://loinc.org"
               code: "LA6568-5"
               display: "Not at all"
+              _display:
+                translation:
+                  - lang: es
+                    content: Ningún día
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 0
@@ -310,6 +450,10 @@ item:
               system: "http://loinc.org"
               code: "LA6569-3"
               display: "Several days"
+              _display:
+                translation:
+                  - lang: es
+                    content: Varios días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 1
@@ -317,6 +461,10 @@ item:
               system: "http://loinc.org"
               code: "LA6570-1"
               display: "More than half the days"
+              _display:
+                translation:
+                  - lang: es
+                    content: Más de la mitad de los días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 2
@@ -324,26 +472,34 @@ item:
               system: "http://loinc.org"
               code: "LA6571-9"
               display: "Nearly every day"
+              _display:
+                translation:
+                  - lang: es
+                    content: Casi todos los días
               extension:
                 - url: "http://hl7.org/fhir/StructureDefinition/itemWeight"
                   valueDecimal: 3
 
-  -     linkId: anxiety-score
-        text: GAD-7 Anxiety Severity Score
-        required: true
-        type: integer
-        readOnly: true
-        itemControl:
-          coding:
-            - code: anxiety-score
-        calculatedExpression:
-          language: text/fhirpath
-          expression: |
-            %resource.repeat(item)
-              .answer.valueCoding.extension
-              .where(url = 'http://hl7.org/fhir/StructureDefinition/itemWeight')
-              .valueDecimal
-              .sum()
+  - linkId: anxiety-score
+    text: GAD-7 Anxiety Severity Score
+    _text:
+      translation:
+        - lang: es
+          content: Puntuación de gravedad de la ansiedad GAD-7
+    required: true
+    type: integer
+    readOnly: true
+    itemControl:
+      coding:
+        - code: anxiety-score
+    calculatedExpression:
+      language: text/fhirpath
+      expression: |
+        %resource.repeat(item)
+          .answer.valueCoding.extension
+          .where(url = 'http://hl7.org/fhir/StructureDefinition/itemWeight')
+          .valueDecimal
+          .sum()
 
 meta:
   profile:

--- a/resources/init-seeds/Questionnaire/healthcare-service-edit.yaml
+++ b/resources/init-seeds/Questionnaire/healthcare-service-edit.yaml
@@ -92,4 +92,4 @@ item:
 meta:
   profile:
     - https://emr-core.beda.software/StructureDefinition/fhir-emr-questionnaire
-url: https://aidbox.emr.beda.software/fhir/Questionnaire/healthcare-service-create
+url: https://aidbox.emr.beda.software/fhir/Questionnaire/healthcare-service-edit

--- a/src/components/DashboardCard/creatinine.tsx
+++ b/src/components/DashboardCard/creatinine.tsx
@@ -1,5 +1,6 @@
 import { InfoOutlined } from '@ant-design/icons';
 import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { Patient } from 'fhir/r4b';
 import { useState } from 'react';
 
@@ -61,6 +62,7 @@ function buildCreatinineChart(gender: Patient['gender']) {
 }
 
 export function CreatinineDashboard({ patient }: Props) {
+    const { i18n } = useLingui();
     const author = selectCurrentUserRoleResource();
     const [refreshKey, setRefreshKey] = useState(0);
     const chart = buildCreatinineChart(patient.gender);
@@ -102,6 +104,7 @@ export function CreatinineDashboard({ patient }: Props) {
                             )}
                         />
                         <QuestionnaireResponseForm
+                            language={i18n.locale}
                             initialQuestionnaireResponse={{
                                 resourceType: 'QuestionnaireResponse',
                                 questionnaire: 'creatinine',

--- a/src/components/DashboardCard/creatinine.tsx
+++ b/src/components/DashboardCard/creatinine.tsx
@@ -1,6 +1,5 @@
 import { InfoOutlined } from '@ant-design/icons';
 import { t } from '@lingui/macro';
-import { useLingui } from '@lingui/react';
 import { Patient } from 'fhir/r4b';
 import { useState } from 'react';
 
@@ -9,6 +8,7 @@ import { questionnaireIdLoader } from '@beda.software/fhir-questionnaire';
 import type { ChartDatumBase } from 'src/components/Chart';
 import { formatAuthored, formatChartDateTime, makeUniqueX } from 'src/components/Chart';
 import { QuestionnaireResponseForm } from 'src/components/QuestionnaireResponseForm';
+import { getCurrentLocale } from 'src/services/i18n';
 import type { ReferenceChartRow, ViewChartConfig } from 'src/uberComponents/ViewChart';
 import { ViewChart } from 'src/uberComponents/ViewChart';
 import { selectCurrentUserRoleResource } from 'src/utils/role';
@@ -62,7 +62,6 @@ function buildCreatinineChart(gender: Patient['gender']) {
 }
 
 export function CreatinineDashboard({ patient }: Props) {
-    const { i18n } = useLingui();
     const author = selectCurrentUserRoleResource();
     const [refreshKey, setRefreshKey] = useState(0);
     const chart = buildCreatinineChart(patient.gender);
@@ -104,7 +103,7 @@ export function CreatinineDashboard({ patient }: Props) {
                             )}
                         />
                         <QuestionnaireResponseForm
-                            language={i18n.locale}
+                            language={getCurrentLocale()}
                             initialQuestionnaireResponse={{
                                 resourceType: 'QuestionnaireResponse',
                                 questionnaire: 'creatinine',

--- a/src/components/QuestionnaireResponseForm/components.tsx
+++ b/src/components/QuestionnaireResponseForm/components.tsx
@@ -57,6 +57,7 @@ export function QuestionnaireResponseForm({
     onFailure,
     readOnly,
     customYupTests,
+    language,
 }: QuestionnaireResponseFormProps) {
     const ItemControlQuestionItemWidgetsFromContext = useContext(ItemControlQuestionItemWidgetsContext);
     const ItemControlGroupItemWidgetsFromContext = useContext(ItemControlGroupItemWidgetsContext);
@@ -112,6 +113,7 @@ export function QuestionnaireResponseForm({
             onFailure={onFailure}
             readOnly={readOnly}
             customYupTests={customYupTests}
+            language={language}
             serviceProvider={serviceProviderProp ?? { service }}
             fhirService={service}
             sdcServiceProvider={sdcServiceProvider}

--- a/src/components/QuestionnairesWizard/index.tsx
+++ b/src/components/QuestionnairesWizard/index.tsx
@@ -1,10 +1,9 @@
-import { useLingui } from '@lingui/react';
-
 import { questionnaireIdLoader } from '@beda.software/fhir-questionnaire';
 
 import { FormFooterComponentProps } from 'src/components/BaseQuestionnaireResponseForm/FormFooter';
 import { QuestionnaireResponseFormDraft } from 'src/components/QuestionnaireResponseFormDraft';
 import { Wizard } from 'src/components/Wizard';
+import { getCurrentLocale } from 'src/services/i18n';
 
 import { QuestionnairesWizardFooter } from './components/QuestionnairesWizardFooter';
 import { QuestionnairesWizardProps, useQuestionnairesWizard } from './hooks';
@@ -13,7 +12,6 @@ export { QuestionnairesWizardFooter } from './components/QuestionnairesWizardFoo
 
 export function QuestionnairesWizard(props: QuestionnairesWizardProps) {
     const { onSuccess, onStepSuccess, initialQuestionnaireResponse, FormFooterComponent, ...other } = props;
-    const { i18n } = useLingui();
 
     const {
         currentQuestionnaire,
@@ -38,7 +36,7 @@ export function QuestionnairesWizard(props: QuestionnairesWizardProps) {
             {...props.wizard}
         >
             <QuestionnaireResponseFormDraft
-                language={i18n.locale}
+                language={getCurrentLocale()}
                 key={currentQuestionnaire?.id}
                 autoSave
                 qrDraftServiceType="local"

--- a/src/components/QuestionnairesWizard/index.tsx
+++ b/src/components/QuestionnairesWizard/index.tsx
@@ -1,3 +1,5 @@
+import { useLingui } from '@lingui/react';
+
 import { questionnaireIdLoader } from '@beda.software/fhir-questionnaire';
 
 import { FormFooterComponentProps } from 'src/components/BaseQuestionnaireResponseForm/FormFooter';
@@ -11,6 +13,7 @@ export { QuestionnairesWizardFooter } from './components/QuestionnairesWizardFoo
 
 export function QuestionnairesWizard(props: QuestionnairesWizardProps) {
     const { onSuccess, onStepSuccess, initialQuestionnaireResponse, FormFooterComponent, ...other } = props;
+    const { i18n } = useLingui();
 
     const {
         currentQuestionnaire,
@@ -35,6 +38,7 @@ export function QuestionnairesWizard(props: QuestionnairesWizardProps) {
             {...props.wizard}
         >
             <QuestionnaireResponseFormDraft
+                language={i18n.locale}
                 key={currentQuestionnaire?.id}
                 autoSave
                 qrDraftServiceType="local"

--- a/src/containers/Appointment/PublicAppointment.tsx
+++ b/src/containers/Appointment/PublicAppointment.tsx
@@ -1,4 +1,5 @@
 import { t, Trans } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { notification } from 'antd';
 import { useEffect, useState } from 'react';
 
@@ -17,6 +18,7 @@ import { history } from 'src/services/history';
 import { S } from './PublicAppointment.styles';
 
 export function PublicAppointment() {
+    const { i18n } = useLingui();
     const practitionerRolePath = ['practitioner-role', 0, 'value', 'Reference'];
     const appToken = getToken();
     const isAnonymousUser = !appToken;
@@ -44,6 +46,7 @@ export function PublicAppointment() {
                     <Spinner />
                 ) : (
                     <QuestionnaireResponseForm
+                        language={i18n.locale}
                         questionnaireLoader={questionnaireIdLoader('public-appointment')}
                         onSuccess={() => {
                             notification.success({

--- a/src/containers/Appointment/PublicAppointment.tsx
+++ b/src/containers/Appointment/PublicAppointment.tsx
@@ -1,5 +1,4 @@
 import { t, Trans } from '@lingui/macro';
-import { useLingui } from '@lingui/react';
 import { notification } from 'antd';
 import { useEffect, useState } from 'react';
 
@@ -14,11 +13,11 @@ import { Spinner } from 'src/components/Spinner';
 import { axiosInstance } from 'src/services';
 import { getToken } from 'src/services/auth';
 import { history } from 'src/services/history';
+import { getCurrentLocale } from 'src/services/i18n';
 
 import { S } from './PublicAppointment.styles';
 
 export function PublicAppointment() {
-    const { i18n } = useLingui();
     const practitionerRolePath = ['practitioner-role', 0, 'value', 'Reference'];
     const appToken = getToken();
     const isAnonymousUser = !appToken;
@@ -46,7 +45,7 @@ export function PublicAppointment() {
                     <Spinner />
                 ) : (
                     <QuestionnaireResponseForm
-                        language={i18n.locale}
+                        language={getCurrentLocale()}
                         questionnaireLoader={questionnaireIdLoader('public-appointment')}
                         onSuccess={() => {
                             notification.success({

--- a/src/containers/EncounterDetails/index.tsx
+++ b/src/containers/EncounterDetails/index.tsx
@@ -1,5 +1,6 @@
 import { AudioOutlined, CheckOutlined, PlusOutlined } from '@ant-design/icons';
 import { t, Trans } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { Button, notification } from 'antd';
 import { Encounter, Patient } from 'fhir/r4b';
 import { useCallback, useState } from 'react';
@@ -191,6 +192,7 @@ function ModalCompleteEncounter(props: { encounter: Encounter; onSuccess: () => 
 
 function CompleteEncounterForm(props: { encounter: Encounter; onSuccess: () => void; closeModal: () => void }) {
     const { encounter, onSuccess, closeModal } = props;
+    const { i18n } = useLingui();
 
     const completeEncounterFormWrapper = useCallback(
         (wrapperProps: FormWrapperProps) => (
@@ -201,6 +203,7 @@ function CompleteEncounterForm(props: { encounter: Encounter; onSuccess: () => v
 
     return (
         <QuestionnaireResponseForm
+            language={i18n.locale}
             questionnaireLoader={questionnaireIdLoader('complete-encounter')}
             launchContextParameters={[
                 {

--- a/src/containers/EncounterDetails/index.tsx
+++ b/src/containers/EncounterDetails/index.tsx
@@ -1,6 +1,5 @@
 import { AudioOutlined, CheckOutlined, PlusOutlined } from '@ant-design/icons';
 import { t, Trans } from '@lingui/macro';
-import { useLingui } from '@lingui/react';
 import { Button, notification } from 'antd';
 import { Encounter, Patient } from 'fhir/r4b';
 import { useCallback, useState } from 'react';
@@ -19,6 +18,7 @@ import { Spinner } from 'src/components/Spinner';
 import { Text } from 'src/components/Typography';
 import { DocumentsList } from 'src/containers/DocumentsList';
 import { ChooseDocumentToCreateModal } from 'src/containers/DocumentsList/ChooseDocumentToCreateModal';
+import { getCurrentLocale } from 'src/services/i18n';
 
 import { AIScribe, useAIScribe } from './AIScribe';
 import { S } from './EncounterDetails.styles';
@@ -192,7 +192,6 @@ function ModalCompleteEncounter(props: { encounter: Encounter; onSuccess: () => 
 
 function CompleteEncounterForm(props: { encounter: Encounter; onSuccess: () => void; closeModal: () => void }) {
     const { encounter, onSuccess, closeModal } = props;
-    const { i18n } = useLingui();
 
     const completeEncounterFormWrapper = useCallback(
         (wrapperProps: FormWrapperProps) => (
@@ -203,7 +202,7 @@ function CompleteEncounterForm(props: { encounter: Encounter; onSuccess: () => v
 
     return (
         <QuestionnaireResponseForm
-            language={i18n.locale}
+            language={getCurrentLocale()}
             questionnaireLoader={questionnaireIdLoader('complete-encounter')}
             launchContextParameters={[
                 {

--- a/src/containers/OrganizationScheduling/NewAppointmentModal/index.tsx
+++ b/src/containers/OrganizationScheduling/NewAppointmentModal/index.tsx
@@ -1,4 +1,5 @@
 import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { HealthcareService, Practitioner, PractitionerRole } from 'fhir/r4b';
 
 import { questionnaireIdLoader } from '@beda.software/fhir-questionnaire';
@@ -21,11 +22,13 @@ interface NewAppointmentModalProps {
 
 export function NewAppointmentModal(props: NewAppointmentModalProps) {
     const { showModal, start, onOk, onCancel } = props;
+    const { i18n } = useLingui();
     const appointmentStartDateTime = start ? formatFHIRDateTime(start) : formatFHIRDateTime(new Date());
 
     return (
         <Modal title={t`New Appointment`} open={showModal} footer={null} onCancel={onCancel}>
             <QuestionnaireResponseForm
+                language={i18n.locale}
                 onSuccess={onOk}
                 questionnaireResponseSaveService={inMemorySaveService}
                 questionnaireLoader={questionnaireIdLoader('new-appointment-prefilled')}

--- a/src/containers/OrganizationScheduling/NewAppointmentModal/index.tsx
+++ b/src/containers/OrganizationScheduling/NewAppointmentModal/index.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro';
-import { useLingui } from '@lingui/react';
 import { HealthcareService, Practitioner, PractitionerRole } from 'fhir/r4b';
 
 import { questionnaireIdLoader } from '@beda.software/fhir-questionnaire';
@@ -8,6 +7,7 @@ import { formatFHIRDateTime } from '@beda.software/fhir-react';
 import { Modal } from 'src/components/Modal';
 import { QuestionnaireResponseForm } from 'src/components/QuestionnaireResponseForm';
 import { inMemorySaveService } from 'src/hooks';
+import { getCurrentLocale } from 'src/services/i18n';
 
 interface NewAppointmentModalProps {
     practitionerRole: PractitionerRole;
@@ -22,13 +22,12 @@ interface NewAppointmentModalProps {
 
 export function NewAppointmentModal(props: NewAppointmentModalProps) {
     const { showModal, start, onOk, onCancel } = props;
-    const { i18n } = useLingui();
     const appointmentStartDateTime = start ? formatFHIRDateTime(start) : formatFHIRDateTime(new Date());
 
     return (
         <Modal title={t`New Appointment`} open={showModal} footer={null} onCancel={onCancel}>
             <QuestionnaireResponseForm
-                language={i18n.locale}
+                language={getCurrentLocale()}
                 onSuccess={onOk}
                 questionnaireResponseSaveService={inMemorySaveService}
                 questionnaireLoader={questionnaireIdLoader('new-appointment-prefilled')}

--- a/src/containers/PatientDetails/PatientDocument/usePatientDocument.ts
+++ b/src/containers/PatientDetails/PatientDocument/usePatientDocument.ts
@@ -1,3 +1,4 @@
+import { useLingui } from '@lingui/react';
 import { Bundle, Communication, ParametersParameter, Provenance, QuestionnaireResponse, Reference } from 'fhir/r4b';
 import _ from 'lodash';
 import { useCallback } from 'react';
@@ -121,6 +122,7 @@ export function usePatientDocument(props: Props): {
     const { questionnaireResponse, questionnaireId, onSuccess, onCancel } = props;
 
     const navigate = useNavigate();
+    const { i18n } = useLingui();
     const { parameters: clinicalParams } = useClinicalContext();
 
     const [response, manager] = useService<PatientDocumentData>(async () => {
@@ -141,7 +143,10 @@ export function usePatientDocument(props: Props): {
 
         return mapSuccess(
             await resolveMap({
-                formData: loadQuestionnaireResponseFormData(formInitialParams),
+                formData: loadQuestionnaireResponseFormData({
+                    ...formInitialParams,
+                    language: i18n.locale,
+                }),
             }),
             ({ formData }) => ({
                 formData,
@@ -149,7 +154,7 @@ export function usePatientDocument(props: Props): {
                 provenance: lastProvenance,
             }),
         );
-    }, [questionnaireResponse, clinicalParams]);
+    }, [questionnaireResponse, clinicalParams, i18n.locale]);
 
     const [sourceResponse] = useService(async () => {
         const result = await getFHIRResources<Provenance>('Provenance', {

--- a/src/containers/PatientDetails/PatientDocument/usePatientDocument.ts
+++ b/src/containers/PatientDetails/PatientDocument/usePatientDocument.ts
@@ -1,4 +1,3 @@
-import { useLingui } from '@lingui/react';
 import { Bundle, Communication, ParametersParameter, Provenance, QuestionnaireResponse, Reference } from 'fhir/r4b';
 import _ from 'lodash';
 import { useCallback } from 'react';
@@ -31,6 +30,7 @@ import {
     QuestionnaireResponseFormSaveResponse,
 } from 'src/hooks/questionnaire-response-form-data';
 import { getFHIRResource, getFHIRResources, service } from 'src/services/fhir';
+import { getCurrentLocale } from 'src/services/i18n';
 import { compileAsFirst } from 'src/utils';
 
 export interface Props {
@@ -122,7 +122,6 @@ export function usePatientDocument(props: Props): {
     const { questionnaireResponse, questionnaireId, onSuccess, onCancel } = props;
 
     const navigate = useNavigate();
-    const { i18n } = useLingui();
     const { parameters: clinicalParams } = useClinicalContext();
 
     const [response, manager] = useService<PatientDocumentData>(async () => {
@@ -145,7 +144,7 @@ export function usePatientDocument(props: Props): {
             await resolveMap({
                 formData: loadQuestionnaireResponseFormData({
                     ...formInitialParams,
-                    language: i18n.locale,
+                    language: getCurrentLocale(),
                 }),
             }),
             ({ formData }) => ({
@@ -154,7 +153,7 @@ export function usePatientDocument(props: Props): {
                 provenance: lastProvenance,
             }),
         );
-    }, [questionnaireResponse, clinicalParams, i18n.locale]);
+    }, [questionnaireResponse, clinicalParams, getCurrentLocale()]);
 
     const [sourceResponse] = useService(async () => {
         const result = await getFHIRResources<Provenance>('Provenance', {

--- a/src/containers/PatientDetails/PatientOrders/index.tsx
+++ b/src/containers/PatientDetails/PatientOrders/index.tsx
@@ -2,6 +2,7 @@
 // Safe to delete this folder if it remains unused long-term.
 import { DownOutlined } from '@ant-design/icons';
 import { t, Trans } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { Input, MenuProps, notification, Dropdown, Space } from 'antd';
 import { Observation, Patient, Provenance } from 'fhir/r4b';
 import { useCallback, useState } from 'react';
@@ -124,6 +125,7 @@ function useOrders() {
 }
 
 export function PatientOrders({ patient }: Props) {
+    const { i18n } = useLingui();
     const { key, questionnaire, setQuestionnaire, reloadListAndClose, close } = useOrders();
 
     const orderFormWrapper = useCallback(
@@ -199,6 +201,7 @@ export function PatientOrders({ patient }: Props) {
                 footer={[]}
             >
                 <QuestionnaireResponseForm
+                    language={i18n.locale}
                     initialQuestionnaireResponse={{
                         resourceType: 'QuestionnaireResponse',
                         questionnaire: 'creatinine',

--- a/src/containers/PatientDetails/PatientOrders/index.tsx
+++ b/src/containers/PatientDetails/PatientOrders/index.tsx
@@ -2,7 +2,6 @@
 // Safe to delete this folder if it remains unused long-term.
 import { DownOutlined } from '@ant-design/icons';
 import { t, Trans } from '@lingui/macro';
-import { useLingui } from '@lingui/react';
 import { Input, MenuProps, notification, Dropdown, Space } from 'antd';
 import { Observation, Patient, Provenance } from 'fhir/r4b';
 import { useCallback, useState } from 'react';
@@ -18,6 +17,7 @@ import { LinkToEdit } from 'src/components/LinkToEdit';
 import { Modal } from 'src/components/Modal';
 import { QuestionnaireResponseForm } from 'src/components/QuestionnaireResponseForm';
 import { ResourceTable } from 'src/components/ResourceTable';
+import { getCurrentLocale } from 'src/services/i18n';
 import { formatHumanDate } from 'src/utils/date';
 const { Search } = Input;
 
@@ -125,7 +125,6 @@ function useOrders() {
 }
 
 export function PatientOrders({ patient }: Props) {
-    const { i18n } = useLingui();
     const { key, questionnaire, setQuestionnaire, reloadListAndClose, close } = useOrders();
 
     const orderFormWrapper = useCallback(
@@ -201,7 +200,7 @@ export function PatientOrders({ patient }: Props) {
                 footer={[]}
             >
                 <QuestionnaireResponseForm
-                    language={i18n.locale}
+                    language={getCurrentLocale()}
                     initialQuestionnaireResponse={{
                         resourceType: 'QuestionnaireResponse',
                         questionnaire: 'creatinine',

--- a/src/containers/PatientDetails/PatientOverviewDynamic/components/EditPatient/index.tsx
+++ b/src/containers/PatientDetails/PatientOverviewDynamic/components/EditPatient/index.tsx
@@ -1,5 +1,4 @@
 import { t, Trans } from '@lingui/macro';
-import { useLingui } from '@lingui/react';
 import { notification } from 'antd';
 import { useCallback } from 'react';
 
@@ -11,6 +10,7 @@ import { FormWrapper } from 'src/components/FormWrapper';
 import { ModalTrigger } from 'src/components/ModalTrigger';
 import { usePatientReload } from 'src/containers/PatientDetails/Dashboard/contexts';
 import { S } from 'src/containers/PatientDetails/PatientOverviewDynamic/PatientOverview.styles';
+import { getCurrentLocale } from 'src/services/i18n';
 
 export function EditPatient() {
     const reload = usePatientReload();
@@ -31,7 +31,6 @@ export function EditPatient() {
 
 function EditPatientForm(props: { reload: () => void; closeModal: () => void }) {
     const { reload, closeModal } = props;
-    const { i18n } = useLingui();
 
     const formWrapper = useCallback(
         (wrapperProps: FormWrapperProps) => <FormWrapper {...wrapperProps} onCancel={closeModal} />,
@@ -40,7 +39,7 @@ function EditPatientForm(props: { reload: () => void; closeModal: () => void }) 
 
     return (
         <QuestionnaireResponseForm
-            language={i18n.locale}
+            language={getCurrentLocale()}
             questionnaireLoader={questionnaireIdLoader('patient-edit')}
             onSuccess={() => {
                 notification.success({ message: t`Patient saved` });

--- a/src/containers/PatientDetails/PatientOverviewDynamic/components/EditPatient/index.tsx
+++ b/src/containers/PatientDetails/PatientOverviewDynamic/components/EditPatient/index.tsx
@@ -1,4 +1,5 @@
 import { t, Trans } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { notification } from 'antd';
 import { useCallback } from 'react';
 
@@ -30,6 +31,7 @@ export function EditPatient() {
 
 function EditPatientForm(props: { reload: () => void; closeModal: () => void }) {
     const { reload, closeModal } = props;
+    const { i18n } = useLingui();
 
     const formWrapper = useCallback(
         (wrapperProps: FormWrapperProps) => <FormWrapper {...wrapperProps} onCancel={closeModal} />,
@@ -38,6 +40,7 @@ function EditPatientForm(props: { reload: () => void; closeModal: () => void }) 
 
     return (
         <QuestionnaireResponseForm
+            language={i18n.locale}
             questionnaireLoader={questionnaireIdLoader('patient-edit')}
             onSuccess={() => {
                 notification.success({ message: t`Patient saved` });

--- a/src/containers/PatientDetails/PatientOverviewDynamic/components/PatientNoteListCard/ModalNoteCreate/index.tsx
+++ b/src/containers/PatientDetails/PatientOverviewDynamic/components/PatientNoteListCard/ModalNoteCreate/index.tsx
@@ -1,4 +1,5 @@
 import { t, Trans } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { Button, notification } from 'antd';
 import { Patient } from 'fhir/r4b';
 import { useCallback } from 'react';
@@ -34,6 +35,7 @@ export const ModalNoteCreate = (props: ModalNoteCreateProps) => {
 
 function NoteCreateForm(props: { onCreate: () => void; closeModal: () => void }) {
     const { onCreate, closeModal } = props;
+    const { i18n } = useLingui();
 
     const formWrapper = useCallback(
         (wrapperProps: FormWrapperProps) => <FormWrapper {...wrapperProps} onCancel={closeModal} />,
@@ -42,6 +44,7 @@ function NoteCreateForm(props: { onCreate: () => void; closeModal: () => void })
 
     return (
         <QuestionnaireResponseForm
+            language={i18n.locale}
             questionnaireLoader={questionnaireIdLoader('patient-note-create')}
             onSuccess={() => {
                 closeModal();

--- a/src/containers/PatientDetails/PatientOverviewDynamic/components/PatientNoteListCard/ModalNoteCreate/index.tsx
+++ b/src/containers/PatientDetails/PatientOverviewDynamic/components/PatientNoteListCard/ModalNoteCreate/index.tsx
@@ -1,5 +1,4 @@
 import { t, Trans } from '@lingui/macro';
-import { useLingui } from '@lingui/react';
 import { Button, notification } from 'antd';
 import { Patient } from 'fhir/r4b';
 import { useCallback } from 'react';
@@ -10,6 +9,7 @@ import { FormWrapperProps } from '@beda.software/fhir-questionnaire/components';
 import { FormWrapper } from 'src/components/FormWrapper';
 import { ModalTrigger } from 'src/components/ModalTrigger';
 import { QuestionnaireResponseForm } from 'src/components/QuestionnaireResponseForm';
+import { getCurrentLocale } from 'src/services/i18n';
 
 interface ModalNoteCreateProps {
     patient: Patient;
@@ -35,7 +35,6 @@ export const ModalNoteCreate = (props: ModalNoteCreateProps) => {
 
 function NoteCreateForm(props: { onCreate: () => void; closeModal: () => void }) {
     const { onCreate, closeModal } = props;
-    const { i18n } = useLingui();
 
     const formWrapper = useCallback(
         (wrapperProps: FormWrapperProps) => <FormWrapper {...wrapperProps} onCancel={closeModal} />,
@@ -44,7 +43,7 @@ function NoteCreateForm(props: { onCreate: () => void; closeModal: () => void })
 
     return (
         <QuestionnaireResponseForm
-            language={i18n.locale}
+            language={getCurrentLocale()}
             questionnaireLoader={questionnaireIdLoader('patient-note-create')}
             onSuccess={() => {
                 closeModal();

--- a/src/containers/PractitionerDetails/PractitionerOverview/index.tsx
+++ b/src/containers/PractitionerDetails/PractitionerOverview/index.tsx
@@ -1,5 +1,6 @@
 import { ContactsOutlined } from '@ant-design/icons';
 import { t, Trans } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { Button, notification } from 'antd';
 import { HealthcareService, Practitioner, PractitionerRole } from 'fhir/r4b';
 import { useCallback } from 'react';
@@ -104,6 +105,7 @@ function EditPractitionerForm(props: {
     closeModal: () => void;
 }) {
     const { practitioner, practitionerRole, reload, closeModal } = props;
+    const { i18n } = useLingui();
 
     const formWrapper = useCallback(
         (wrapperProps: FormWrapperProps) => <FormWrapper {...wrapperProps} onCancel={closeModal} />,
@@ -112,6 +114,7 @@ function EditPractitionerForm(props: {
 
     return (
         <QuestionnaireResponseForm
+            language={i18n.locale}
             questionnaireLoader={questionnaireIdLoader('practitioner-edit')}
             launchContextParameters={[
                 { name: 'Practitioner', resource: practitioner },

--- a/src/containers/PractitionerDetails/PractitionerOverview/index.tsx
+++ b/src/containers/PractitionerDetails/PractitionerOverview/index.tsx
@@ -1,6 +1,5 @@
 import { ContactsOutlined } from '@ant-design/icons';
 import { t, Trans } from '@lingui/macro';
-import { useLingui } from '@lingui/react';
 import { Button, notification } from 'antd';
 import { HealthcareService, Practitioner, PractitionerRole } from 'fhir/r4b';
 import { useCallback } from 'react';
@@ -13,6 +12,7 @@ import { DashboardCard } from 'src/components/DashboardCard';
 import { FormWrapper } from 'src/components/FormWrapper';
 import { ModalTrigger } from 'src/components/ModalTrigger';
 import { QuestionnaireResponseForm } from 'src/components/QuestionnaireResponseForm';
+import { getCurrentLocale } from 'src/services/i18n';
 
 import s from './PractitionerOverview.module.scss';
 import { S } from './PractitionerOverview.styles';
@@ -105,7 +105,6 @@ function EditPractitionerForm(props: {
     closeModal: () => void;
 }) {
     const { practitioner, practitionerRole, reload, closeModal } = props;
-    const { i18n } = useLingui();
 
     const formWrapper = useCallback(
         (wrapperProps: FormWrapperProps) => <FormWrapper {...wrapperProps} onCancel={closeModal} />,
@@ -114,7 +113,7 @@ function EditPractitionerForm(props: {
 
     return (
         <QuestionnaireResponseForm
-            language={i18n.locale}
+            language={getCurrentLocale()}
             questionnaireLoader={questionnaireIdLoader('practitioner-edit')}
             launchContextParameters={[
                 { name: 'Practitioner', resource: practitioner },

--- a/src/containers/Scheduling/ScheduleCalendar/components/EditAppointmentModal/index.tsx
+++ b/src/containers/Scheduling/ScheduleCalendar/components/EditAppointmentModal/index.tsx
@@ -1,4 +1,5 @@
 import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { PractitionerRole } from 'fhir/r4b';
 import { useCallback } from 'react';
 
@@ -20,6 +21,7 @@ interface Props {
 
 export function EditAppointmentModal(props: Props) {
     const { showModal, onClose, onSubmit, appointmentId, practitionerRole } = props;
+    const { i18n } = useLingui();
 
     const formWrapper = useCallback(
         (wrapperProps: FormWrapperProps) => <FormWrapper {...wrapperProps} onCancel={onClose} />,
@@ -29,6 +31,7 @@ export function EditAppointmentModal(props: Props) {
     return (
         <Modal open={showModal} title={t`Edit Appointment`} footer={null} onCancel={onClose}>
             <QuestionnaireResponseForm
+                language={i18n.locale}
                 questionnaireLoader={questionnaireIdLoader('edit-appointment')}
                 questionnaireResponseSaveService={inMemorySaveService}
                 launchContextParameters={[

--- a/src/containers/Scheduling/ScheduleCalendar/components/EditAppointmentModal/index.tsx
+++ b/src/containers/Scheduling/ScheduleCalendar/components/EditAppointmentModal/index.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro';
-import { useLingui } from '@lingui/react';
 import { PractitionerRole } from 'fhir/r4b';
 import { useCallback } from 'react';
 
@@ -10,6 +9,7 @@ import { FormWrapper } from 'src/components/FormWrapper';
 import { Modal } from 'src/components/Modal';
 import { QuestionnaireResponseForm } from 'src/components/QuestionnaireResponseForm';
 import { inMemorySaveService } from 'src/hooks';
+import { getCurrentLocale } from 'src/services/i18n';
 
 interface Props {
     practitionerRole: PractitionerRole;
@@ -21,7 +21,6 @@ interface Props {
 
 export function EditAppointmentModal(props: Props) {
     const { showModal, onClose, onSubmit, appointmentId, practitionerRole } = props;
-    const { i18n } = useLingui();
 
     const formWrapper = useCallback(
         (wrapperProps: FormWrapperProps) => <FormWrapper {...wrapperProps} onCancel={onClose} />,
@@ -31,7 +30,7 @@ export function EditAppointmentModal(props: Props) {
     return (
         <Modal open={showModal} title={t`Edit Appointment`} footer={null} onCancel={onClose}>
             <QuestionnaireResponseForm
-                language={i18n.locale}
+                language={getCurrentLocale()}
                 questionnaireLoader={questionnaireIdLoader('edit-appointment')}
                 questionnaireResponseSaveService={inMemorySaveService}
                 launchContextParameters={[

--- a/src/containers/Scheduling/ScheduleCalendar/components/NewAppointmentModal/index.tsx
+++ b/src/containers/Scheduling/ScheduleCalendar/components/NewAppointmentModal/index.tsx
@@ -1,4 +1,5 @@
 import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { PractitionerRole } from 'fhir/r4b';
 
 import { questionnaireIdLoader } from '@beda.software/fhir-questionnaire';
@@ -19,11 +20,13 @@ interface NewAppointmentModalProps {
 
 export function NewAppointmentModal(props: NewAppointmentModalProps) {
     const { showModal, start, onOk, onCancel } = props;
+    const { i18n } = useLingui();
     const appointmentStartDateTime = start ? formatFHIRDateTime(start) : formatFHIRDateTime(new Date());
 
     return (
         <Modal title={t`New Appointment`} open={showModal} footer={null} onCancel={onCancel}>
             <QuestionnaireResponseForm
+                language={i18n.locale}
                 onSuccess={onOk}
                 questionnaireResponseSaveService={inMemorySaveService}
                 questionnaireLoader={questionnaireIdLoader('new-appointment')}

--- a/src/containers/Scheduling/ScheduleCalendar/components/NewAppointmentModal/index.tsx
+++ b/src/containers/Scheduling/ScheduleCalendar/components/NewAppointmentModal/index.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro';
-import { useLingui } from '@lingui/react';
 import { PractitionerRole } from 'fhir/r4b';
 
 import { questionnaireIdLoader } from '@beda.software/fhir-questionnaire';
@@ -8,6 +7,7 @@ import { formatFHIRDateTime } from '@beda.software/fhir-react';
 import { Modal } from 'src/components/Modal';
 import { QuestionnaireResponseForm } from 'src/components/QuestionnaireResponseForm';
 import { inMemorySaveService } from 'src/hooks';
+import { getCurrentLocale } from 'src/services/i18n';
 
 interface NewAppointmentModalProps {
     practitionerRole: PractitionerRole;
@@ -20,13 +20,12 @@ interface NewAppointmentModalProps {
 
 export function NewAppointmentModal(props: NewAppointmentModalProps) {
     const { showModal, start, onOk, onCancel } = props;
-    const { i18n } = useLingui();
     const appointmentStartDateTime = start ? formatFHIRDateTime(start) : formatFHIRDateTime(new Date());
 
     return (
         <Modal title={t`New Appointment`} open={showModal} footer={null} onCancel={onCancel}>
             <QuestionnaireResponseForm
-                language={i18n.locale}
+                language={getCurrentLocale()}
                 onSuccess={onOk}
                 questionnaireResponseSaveService={inMemorySaveService}
                 questionnaireLoader={questionnaireIdLoader('new-appointment')}

--- a/src/containers/SetPassword/index.tsx
+++ b/src/containers/SetPassword/index.tsx
@@ -1,4 +1,5 @@
 import { Trans, t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -19,6 +20,7 @@ interface SetPasswordProps {
 export function SetPassword(props: SetPasswordProps) {
     const { customYupTests } = props;
     const { code } = useParams<{ code: string }>();
+    const { i18n } = useLingui();
 
     const saveFormWrapper = useCallback(
         (wrapperProps: FormWrapperProps) => <FormWrapper {...wrapperProps} saveButtonTitle={t`Save`} />,
@@ -32,6 +34,7 @@ export function SetPassword(props: SetPasswordProps) {
                     <Trans>Set password</Trans>
                 </Title>
                 <QuestionnaireResponseForm
+                    language={i18n.locale}
                     customYupTests={customYupTests}
                     questionnaireLoader={questionnaireIdLoader('set-password')}
                     questionnaireResponseSaveService={inMemorySaveService}

--- a/src/containers/SetPassword/index.tsx
+++ b/src/containers/SetPassword/index.tsx
@@ -1,5 +1,4 @@
 import { Trans, t } from '@lingui/macro';
-import { useLingui } from '@lingui/react';
 import { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -10,6 +9,7 @@ import { FormWrapper } from 'src/components/FormWrapper';
 import { QuestionnaireResponseForm } from 'src/components/QuestionnaireResponseForm';
 import { Title } from 'src/components/Typography';
 import { inMemorySaveService } from 'src/hooks';
+import { getCurrentLocale } from 'src/services/i18n';
 
 import { S } from './SetPassword.styles';
 
@@ -20,7 +20,6 @@ interface SetPasswordProps {
 export function SetPassword(props: SetPasswordProps) {
     const { customYupTests } = props;
     const { code } = useParams<{ code: string }>();
-    const { i18n } = useLingui();
 
     const saveFormWrapper = useCallback(
         (wrapperProps: FormWrapperProps) => <FormWrapper {...wrapperProps} saveButtonTitle={t`Save`} />,
@@ -34,7 +33,7 @@ export function SetPassword(props: SetPasswordProps) {
                     <Trans>Set password</Trans>
                 </Title>
                 <QuestionnaireResponseForm
-                    language={i18n.locale}
+                    language={getCurrentLocale()}
                     customYupTests={customYupTests}
                     questionnaireLoader={questionnaireIdLoader('set-password')}
                     questionnaireResponseSaveService={inMemorySaveService}

--- a/src/services/valueset-expand.ts
+++ b/src/services/valueset-expand.ts
@@ -102,6 +102,7 @@ export async function expandFHIRValueSet(answerValueSet: string | undefined, sea
             params: {
                 ...(searchText ? { filter: searchText } : {}),
                 count: 50,
+                displayLanguage: getCurrentLocale(),
             },
         }),
         (expandedValueSet) => {

--- a/src/uberComponents/QuestionnaireModal/index.tsx
+++ b/src/uberComponents/QuestionnaireModal/index.tsx
@@ -1,5 +1,4 @@
 import { PlusOutlined } from '@ant-design/icons';
-import { useLingui } from '@lingui/react';
 import { Button, notification } from 'antd';
 import { ParametersParameter, Reference } from 'fhir/r4b';
 import { useState } from 'react';
@@ -13,6 +12,7 @@ import {
     persistSaveService,
     questionnaireIdLoader,
 } from 'src/hooks/questionnaire-response-form-data';
+import { getCurrentLocale } from 'src/services/i18n';
 
 export interface QuestionnaireModalProps {
     questionnaire: Reference;
@@ -27,7 +27,6 @@ export function QuestionanireModal({
     launchContextParameters,
     onSuccess,
 }: QuestionnaireModalProps) {
-    const { i18n } = useLingui();
     const [isModalVisible, setIsModalVisible] = useState(false);
     const title = questionnaire.display ?? questionnaire.reference ?? 'N/A';
 
@@ -57,7 +56,7 @@ export function QuestionanireModal({
                 maskClosable={false}
             >
                 <QuestionnaireResponseForm
-                    language={i18n.locale}
+                    language={getCurrentLocale()}
                     initialQuestionnaireResponse={{
                         questionnaire: parseFHIRReference(questionnaire).id,
                         subject,

--- a/src/uberComponents/QuestionnaireModal/index.tsx
+++ b/src/uberComponents/QuestionnaireModal/index.tsx
@@ -1,4 +1,5 @@
 import { PlusOutlined } from '@ant-design/icons';
+import { useLingui } from '@lingui/react';
 import { Button, notification } from 'antd';
 import { ParametersParameter, Reference } from 'fhir/r4b';
 import { useState } from 'react';
@@ -26,6 +27,7 @@ export function QuestionanireModal({
     launchContextParameters,
     onSuccess,
 }: QuestionnaireModalProps) {
+    const { i18n } = useLingui();
     const [isModalVisible, setIsModalVisible] = useState(false);
     const title = questionnaire.display ?? questionnaire.reference ?? 'N/A';
 
@@ -55,6 +57,7 @@ export function QuestionanireModal({
                 maskClosable={false}
             >
                 <QuestionnaireResponseForm
+                    language={i18n.locale}
                     initialQuestionnaireResponse={{
                         questionnaire: parseFHIRReference(questionnaire).id,
                         subject,

--- a/src/uberComponents/ResourceListPage/actions.tsx
+++ b/src/uberComponents/ResourceListPage/actions.tsx
@@ -1,4 +1,5 @@
 import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 import { Button, ModalProps, notification } from 'antd';
 import { Bundle, ParametersParameter, Resource } from 'fhir/r4b';
 import { omit } from 'lodash';
@@ -40,6 +41,7 @@ export function RecordQuestionnaireAction<R extends Resource>({
     reload: () => void;
     defaultLaunchContext: ParametersParameter[];
 }) {
+    const { i18n } = useLingui();
     return (
         <ModalTrigger
             title={action.title}
@@ -52,6 +54,7 @@ export function RecordQuestionnaireAction<R extends Resource>({
         >
             {({ closeModal }) => (
                 <QuestionnaireResponseForm
+                    language={i18n.locale}
                     questionnaireLoader={questionnaireIdLoader(action.questionnaireId)}
                     launchContextParameters={[
                         ...defaultLaunchContext,
@@ -80,6 +83,7 @@ interface HeaderQuestionnaireActionProps {
 }
 
 export function HeaderQuestionnaireAction({ action, reload, defaultLaunchContext }: HeaderQuestionnaireActionProps) {
+    const { i18n } = useLingui();
     return (
         <ModalTrigger
             title={action.title}
@@ -92,6 +96,7 @@ export function HeaderQuestionnaireAction({ action, reload, defaultLaunchContext
         >
             {({ closeModal }) => (
                 <QuestionnaireResponseForm
+                    language={i18n.locale}
                     questionnaireLoader={questionnaireIdLoader(action.questionnaireId)}
                     onSuccess={() => {
                         closeModal();
@@ -121,6 +126,7 @@ export function BatchQuestionnaireAction<R extends Resource>({
     disabled?: boolean;
     defaultLaunchContext: ParametersParameter[];
 }) {
+    const { i18n } = useLingui();
     if (action.type === 'questionnaire') {
         return (
             <ModalTrigger
@@ -134,6 +140,7 @@ export function BatchQuestionnaireAction<R extends Resource>({
             >
                 {({ closeModal }) => (
                     <QuestionnaireResponseForm
+                        language={i18n.locale}
                         questionnaireLoader={questionnaireIdLoader(action.questionnaireId)}
                         launchContextParameters={[
                             ...defaultLaunchContext,

--- a/src/uberComponents/ResourceListPage/actions.tsx
+++ b/src/uberComponents/ResourceListPage/actions.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro';
-import { useLingui } from '@lingui/react';
 import { Button, ModalProps, notification } from 'antd';
 import { Bundle, ParametersParameter, Resource } from 'fhir/r4b';
 import { omit } from 'lodash';
@@ -9,6 +8,7 @@ import { questionnaireIdLoader } from '@beda.software/fhir-questionnaire';
 
 import { ModalTrigger } from 'src/components/ModalTrigger';
 import { QuestionnaireResponseForm, QRFProps } from 'src/components/QuestionnaireResponseForm';
+import { getCurrentLocale } from 'src/services/i18n';
 
 import { S } from './styles';
 import {
@@ -41,7 +41,6 @@ export function RecordQuestionnaireAction<R extends Resource>({
     reload: () => void;
     defaultLaunchContext: ParametersParameter[];
 }) {
-    const { i18n } = useLingui();
     return (
         <ModalTrigger
             title={action.title}
@@ -54,7 +53,7 @@ export function RecordQuestionnaireAction<R extends Resource>({
         >
             {({ closeModal }) => (
                 <QuestionnaireResponseForm
-                    language={i18n.locale}
+                    language={getCurrentLocale()}
                     questionnaireLoader={questionnaireIdLoader(action.questionnaireId)}
                     launchContextParameters={[
                         ...defaultLaunchContext,
@@ -83,7 +82,6 @@ interface HeaderQuestionnaireActionProps {
 }
 
 export function HeaderQuestionnaireAction({ action, reload, defaultLaunchContext }: HeaderQuestionnaireActionProps) {
-    const { i18n } = useLingui();
     return (
         <ModalTrigger
             title={action.title}
@@ -96,7 +94,7 @@ export function HeaderQuestionnaireAction({ action, reload, defaultLaunchContext
         >
             {({ closeModal }) => (
                 <QuestionnaireResponseForm
-                    language={i18n.locale}
+                    language={getCurrentLocale()}
                     questionnaireLoader={questionnaireIdLoader(action.questionnaireId)}
                     onSuccess={() => {
                         closeModal();
@@ -126,7 +124,6 @@ export function BatchQuestionnaireAction<R extends Resource>({
     disabled?: boolean;
     defaultLaunchContext: ParametersParameter[];
 }) {
-    const { i18n } = useLingui();
     if (action.type === 'questionnaire') {
         return (
             <ModalTrigger
@@ -140,7 +137,7 @@ export function BatchQuestionnaireAction<R extends Resource>({
             >
                 {({ closeModal }) => (
                     <QuestionnaireResponseForm
-                        language={i18n.locale}
+                        language={getCurrentLocale()}
                         questionnaireLoader={questionnaireIdLoader(action.questionnaireId)}
                         launchContextParameters={[
                             ...defaultLaunchContext,

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,10 +447,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@beda.software/fhir-questionnaire@^0.1.0-alpha.13":
-  version "0.1.0-alpha.13"
-  resolved "https://registry.yarnpkg.com/@beda.software/fhir-questionnaire/-/fhir-questionnaire-0.1.0-alpha.13.tgz#010251725e3ffb844661db1856b93dbace490639"
-  integrity sha512-MSghN+LJ1sE2hvqA6S2w0YYuDq7hfAcdaKrNNDSn0yJDvB2pM1Hm8MPkwLKP6VqjwbvmQg7VTwlNOTdip+dMjw==
+"@beda.software/fhir-questionnaire@^0.1.0-alpha.15":
+  version "0.1.0-alpha.15"
+  resolved "https://registry.yarnpkg.com/@beda.software/fhir-questionnaire/-/fhir-questionnaire-0.1.0-alpha.15.tgz#8ed904fc906a39dc46809f2d7c6a4e10c000297b"
+  integrity sha512-PQw2tayHe+Zj3u1pZVQ3mpxm4Mb6BGgaULWf7HLt2Y27TVEaS2wP1trvLJx7jUMETta2+fp1q3Sn7U10q6iimA==
   dependencies:
     "@beda.software/fhir-react" "^1.11.1"
     "@beda.software/remote-data" "^1.1.4"
@@ -464,7 +464,7 @@
     moment "^2.30.1"
     query-string "^7.1.1"
     react-hook-form "^7.49.3"
-    sdc-qrf "^1.1.0-alpha.11"
+    sdc-qrf "^1.1.0-alpha.13"
     tslib "^2.8.1"
     yup "^1.2.0"
 
@@ -12299,10 +12299,10 @@ scroll-into-view-if-needed@^3.1.0:
   dependencies:
     compute-scroll-into-view "^3.0.2"
 
-sdc-qrf@^1.1.0-alpha.11:
-  version "1.1.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/sdc-qrf/-/sdc-qrf-1.1.0-alpha.11.tgz#9f15959d909aaa2889c5fd791f14ff9e83064dca"
-  integrity sha512-WHFx1S2s652Lox8WlUD3+c4WohZExP/K1pFkHL9sLhwrxZXN7u1/I4YaRIgCGouV4HHTP/XE4Ai+b81lsVbWhA==
+sdc-qrf@^1.1.0-alpha.13:
+  version "1.1.0-alpha.13"
+  resolved "https://registry.yarnpkg.com/sdc-qrf/-/sdc-qrf-1.1.0-alpha.13.tgz#cc076c0592c690feba49a5543793104d6ee6be45"
+  integrity sha512-Xv7ZCPZ97rrFHD3ji3HuXzXAhrqWGAHVebxqREHJWmhIDI4vsuMia2PwJEYl9zYf9eA12Tr5hbRzhXCNmuZLRQ==
   dependencies:
     classnames "^2.5.1"
     fhirpath "^3.18.0"


### PR DESCRIPTION
## Summary
- Pass the active locale through QuestionnaireResponseForm and related call sites so questionnaire text follows the current language.
- Bump `fhir-questionnaire` and `sdc-qrf` for translation/merge support.
- Move `encounter-create` seeds into a folder with DE/ES translations, including `answerOption` displays.
- Add Spanish translations to the GAD-7 questionnaire seed.
- Fix `healthcare-service-edit` questionnaire URL to match its id.